### PR TITLE
Add ability to specify host and port parameters for serve goal

### DIFF
--- a/src/main/java/io/qameta/allure/maven/AllureCommandline.java
+++ b/src/main/java/io/qameta/allure/maven/AllureCommandline.java
@@ -59,7 +59,7 @@ public class AllureCommandline {
         return execute(commandLine, 60);
     }
 
-    public int serve(List<Path> resultsPaths, Path reportPath) throws IOException {
+    public int serve(List<Path> resultsPaths, Path reportPath, String serveHost, Integer servePort) throws IOException {
 
         this.checkAllureExists();
 
@@ -67,6 +67,14 @@ public class AllureCommandline {
 
         CommandLine commandLine = new CommandLine(getAllureExecutablePath().toAbsolutePath().toFile());
         commandLine.addArgument("serve");
+        if (serveHost != null && serveHost.matches("(\\d{1,3}\\.){3}\\d{1,3}")) {
+            commandLine.addArgument("--host");
+            commandLine.addArgument(serveHost);
+        }
+        if (servePort > 0) {
+            commandLine.addArgument("--port");
+            commandLine.addArgument("" + servePort);
+        }
         for (Path resultsPath : resultsPaths) {
             commandLine.addArgument(resultsPath.toAbsolutePath().toString(), true);
         }

--- a/src/main/java/io/qameta/allure/maven/AllureGenerateMojo.java
+++ b/src/main/java/io/qameta/allure/maven/AllureGenerateMojo.java
@@ -81,6 +81,18 @@ public abstract class AllureGenerateMojo extends AllureBaseMojo {
     protected String serveTimeout;
 
     /**
+     * Serve host parameter.
+     */
+    @Parameter(property = "allure.serve.host")
+    protected String serveHost;
+
+    /**
+     * Serve port parameter.
+     */
+    @Parameter(property = "allure.serve.port", defaultValue = "0")
+    protected Integer servePort;
+
+    /**
      * The path to the allure.properties file
      */
     @Parameter(defaultValue = "report.properties")

--- a/src/main/java/io/qameta/allure/maven/AllureServeMojo.java
+++ b/src/main/java/io/qameta/allure/maven/AllureServeMojo.java
@@ -49,7 +49,7 @@ public class AllureServeMojo extends AllureGenerateMojo {
                     = new AllureCommandline(Paths.get(getInstallDirectory()), reportVersion, this.serveTimeout);
 
             getLog().info("Generate report to " + reportPath);
-            commandline.serve(resultsPaths, reportPath);
+            commandline.serve(resultsPaths, reportPath, this.serveHost, this.servePort);
             getLog().info("Report generated successfully.");
         } catch (Exception e) {
             getLog().error("Can't generate allure report data", e);


### PR DESCRIPTION
[//]: # (
. Thank you so much for sending us a pull request! 
.
. Make sure you have a clear name for your pull request. 
. The name should start with a capital letter and no dot is required in the end of the sentence.
. To link the request with isses use the following notation: (fixes #123, fixes #321\)
.
. An example of good pull request names:
. - Add Russian translation (fixes #123\)
. - Add an ability to disable default plugins
. - Support emoji in test descriptions
)

### Context
[//]: # (
Describe the problem or feature in addition to a link to the issues
)
Allure commandline supports `--port` option for `serve` command and will also support `--host` option [#662](https://github.com/allure-framework/allure2/issues/662). But allure maven plugin does not support corresponding parameters. In this pull request I added `servePort` and `serveHost` parameters to plugin.
If this parameters are not specified functionality stays the same.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
