### PR TITLE
Added support for cli --profile argument

### DIFF
--- a/src/main/java/io/qameta/allure/maven/AllureGenerateMojo.java
+++ b/src/main/java/io/qameta/allure/maven/AllureGenerateMojo.java
@@ -1,6 +1,7 @@
 package io.qameta.allure.maven;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.apache.commons.lang3.text.StrSubstitutor;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.doxia.sink.Sink;
@@ -22,7 +23,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
 
 import static io.qameta.allure.maven.AllureCommandline.ALLURE_DEFAULT_VERSION;
 import static io.qameta.allure.maven.DownloadUtils.getAllureDownloadUrl;
@@ -101,6 +107,9 @@ public abstract class AllureGenerateMojo extends AllureBaseMojo {
     @Parameter(property = "allure.download.url")
     private String allureDownloadUrl;
 
+    @Parameter(property = "allure.profile")
+    protected String profile;
+
     @Parameter(property = "session", defaultValue = "${session}", readonly = true)
     private MavenSession session;
 
@@ -132,6 +141,7 @@ public abstract class AllureGenerateMojo extends AllureBaseMojo {
 
             getLog().info(format("Generate Allure report (%s) with version %s", getMojoName(), reportVersion != null ? reportVersion : ALLURE_DEFAULT_VERSION));
             getLog().info("Generate Allure report to " + getReportDirectory());
+            getLog().info("Using Allure profile: " + (profile == null ? "default" : profile));
 
             List<Path> inputDirectories = getInputDirectories();
             if (inputDirectories.isEmpty()) {
@@ -202,7 +212,7 @@ public abstract class AllureGenerateMojo extends AllureBaseMojo {
             getLog().info(String.format("Allure installation directory %s", installDirectory));
             getLog().info(String.format("Try to finding out allure %s", version));
 
-            AllureCommandline commandline = new AllureCommandline(Paths.get(installDirectory), reportVersion);
+            AllureCommandline commandline = new AllureCommandline(Paths.get(installDirectory), reportVersion, getLog());
             if (commandline.allureNotExists()) {
                 final String url = getAllureDownloadUrl(version, allureDownloadUrl);
                 getLog().info("Downloading allure commandline...");
@@ -220,7 +230,8 @@ public abstract class AllureGenerateMojo extends AllureBaseMojo {
             Path reportPath = Paths.get(getReportDirectory());
 
             AllureCommandline commandline
-                    = new AllureCommandline(Paths.get(getInstallDirectory()), reportVersion, reportTimeout);
+                    = new AllureCommandline(Paths.get(getInstallDirectory()), reportVersion, reportTimeout,
+                    profile, getLog());
 
             getLog().info("Generate report to " + reportPath);
             commandline.generateReport(resultsPaths, reportPath);

--- a/src/main/java/io/qameta/allure/maven/AllureInstallMojo.java
+++ b/src/main/java/io/qameta/allure/maven/AllureInstallMojo.java
@@ -43,7 +43,7 @@ public class AllureInstallMojo extends AbstractMojo {
             getLog().info(String.format("Allure installation directory %s", installDirectory));
             getLog().info(String.format("Try to finding out allure %s", version));
 
-            AllureCommandline commandline = new AllureCommandline(Paths.get(installDirectory), reportVersion);
+            AllureCommandline commandline = new AllureCommandline(Paths.get(installDirectory), reportVersion, getLog());
             if (commandline.allureNotExists()) {
                 final String url = getAllureDownloadUrl(version, allureDownloadUrl);
                 getLog().info("Downloading allure commandline from " + url);

--- a/src/main/java/io/qameta/allure/maven/AllureServeMojo.java
+++ b/src/main/java/io/qameta/allure/maven/AllureServeMojo.java
@@ -1,8 +1,5 @@
 package io.qameta.allure.maven;
 
-import org.apache.maven.plugin.AbstractMojo;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -12,8 +9,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
-
-import static java.lang.String.format;
 
 /**
  * Calls allure serve command.
@@ -63,8 +58,9 @@ public class AllureServeMojo extends AllureGenerateMojo {
         try {
             Path reportPath = Paths.get(getReportDirectory());
 
-            AllureCommandline commandline
-                    = new AllureCommandline(Paths.get(getInstallDirectory()), reportVersion, this.serveTimeout);
+            AllureCommandline commandline =
+                    new AllureCommandline(Paths.get(getInstallDirectory()), reportVersion,
+                            this.serveTimeout, profile, getLog());
 
             getLog().info("Generate report to " + reportPath);
             commandline.serve(resultsPaths, reportPath, this.serveHost, this.servePort);


### PR DESCRIPTION
### Context
Added ability to select profile with profile configuration parameter of plugin, this will lead to behaviour: 
WHEN parameter <profile>selectedProfile</profile>  is present in <configuration> of plugin
THEN argument "--profile selectedProfile " will be added to generate & serve cli commands

#### Checklist
- [ ] Added profile support 
- [ ] Added logging of constructed cli command to console 

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
