### PR TITLE
By default, let Maven download Allure Command Line (fixes #141)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -253,6 +253,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-artifact-transfer</artifactId>
+            <version>0.12.0</version>
+        </dependency>
         <!-- fix dependency hell with allure-report-data-->
         <dependency>
             <artifactId>commons-beanutils</artifactId>

--- a/src/it/feature-without-version-property/pom.xml
+++ b/src/it/feature-without-version-property/pom.xml
@@ -15,9 +15,6 @@
                 <groupId>@project.groupId@</groupId>
                 <artifactId>@project.artifactId@</artifactId>
                 <version>@project.version@</version>
-                <configuration>
-                    <reportVersion>2.8.1</reportVersion>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/it/old-report-version-plugin/pom.xml
+++ b/src/it/old-report-version-plugin/pom.xml
@@ -8,10 +8,6 @@
     <version>1.0-SNAPSHOT</version>
     <name>Allure Report Test</name>
 
-    <properties>
-        <allure.version>1.4.19</allure.version>
-    </properties>
-    
     <build>
         <plugins>
             <plugin>
@@ -40,7 +36,7 @@
                 <artifactId>@project.artifactId@</artifactId>
                 <version>@project.version@</version>
                 <configuration>
-                    <reportVersion>2.8.1</reportVersion>
+                    <reportVersion>2.7.0</reportVersion>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/it/old-report-version-plugin/verify.groovy
+++ b/src/it/old-report-version-plugin/verify.groovy
@@ -1,8 +1,12 @@
 import java.nio.file.Paths
 
 import static io.qameta.allure.maven.TestHelper.checkReportDirectory
+import static org.hamcrest.CoreMatchers.containsString
+import static org.junit.Assert.*
 
 def base = Paths.get(basedir.absolutePath, 'target', 'site')
 
 checkReportDirectory(base.resolve('allure'), 1)
 checkReportDirectory(base.resolve('allure-maven-plugin'), 1)
+
+assertThat Paths.get(basedir.absolutePath, 'build.log').toFile().text, containsString('from https://dl.bintray.com/')

--- a/src/main/java/io/qameta/allure/maven/AllureInstallMojo.java
+++ b/src/main/java/io/qameta/allure/maven/AllureInstallMojo.java
@@ -15,6 +15,9 @@
  */
 package io.qameta.allure.maven;
 
+import java.io.IOException;
+import java.nio.file.Paths;
+
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -23,11 +26,7 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.settings.crypto.SettingsDecrypter;
-
-import java.nio.file.Paths;
-
-import static io.qameta.allure.maven.AllureCommandline.ALLURE_DEFAULT_VERSION;
-import static io.qameta.allure.maven.DownloadUtils.getAllureDownloadUrl;
+import org.apache.maven.shared.transfer.dependencies.resolve.DependencyResolver;
 
 /**
  * Install allure tool.
@@ -51,21 +50,27 @@ public class AllureInstallMojo extends AbstractMojo {
     @Component(role = SettingsDecrypter.class)
     private SettingsDecrypter decrypter;
 
+    @Component
+    private DependencyResolver dependencyResolver;
+
     @Override
     public void execute() throws MojoExecutionException {
         try {
-            final String version = reportVersion != null ? reportVersion : ALLURE_DEFAULT_VERSION;
-            getLog().info(String.format("Allure installation directory %s", installDirectory));
-            getLog().info(String.format("Try to finding out allure %s", version));
-
             AllureCommandline commandline = new AllureCommandline(Paths.get(installDirectory), reportVersion);
+            getLog().info(String.format("Allure installation directory %s", installDirectory));
+            getLog().info(String.format("Try to finding out allure %s", commandline.getVersion()));
+
             if (commandline.allureNotExists()) {
-                final String url = getAllureDownloadUrl(version, allureDownloadUrl);
-                getLog().info("Downloading allure commandline from " + url);
-                commandline.download(url, ProxyUtils.getProxy(session, decrypter));
-                getLog().info("Downloading allure commandline complete");
+                String downloadUrl = DownloadUtils.getAllureDownloadUrl(commandline.getVersion (), allureDownloadUrl);
+                if (downloadUrl == null) {
+                    commandline.downloadWithMaven(session, dependencyResolver);
+                } else {
+                    getLog().info("Downloading allure commandline from " + downloadUrl);
+                    commandline.download(downloadUrl, ProxyUtils.getProxy(session, decrypter));
+                    getLog().info("Downloading allure commandline complete");
+                }
             }
-        } catch (Exception e) {
+        } catch (IOException e) {
             getLog().error("Can't install allure", e);
             throw new MojoExecutionException("Can't install allure", e);
         }

--- a/src/main/java/io/qameta/allure/maven/DownloadUtils.java
+++ b/src/main/java/io/qameta/allure/maven/DownloadUtils.java
@@ -25,17 +25,18 @@ public final class DownloadUtils {
 
     private static final String BINTRAY_TEMPLATE = "https://dl.bintray.com/qameta/generic/io/qameta/allure/allure/%s/allure-%s.zip";
 
-    private static final String CENTRAL_TEMPLATE = "https://repo.maven.apache.org/maven2/io/qameta/allure/allure-commandline/%s/allure-commandline-%s.zip";
-
+    /**
+     * This helper returns the canonical download URL for the allure CLI if none was specified.
+     * It returns null if the version is new enough to be available from Maven Central.
+     */
     public static String getAllureDownloadUrl(final String version, final String downloadUrl) {
         if (downloadUrl != null) {
             return downloadUrl;
         }
         if (versionCompare(version, "2.8.0") < 0) {
             return BINTRAY_TEMPLATE;
-        } else {
-            return CENTRAL_TEMPLATE;
         }
+        return null;
     }
 
     private static Integer versionCompare(String first, String second) {


### PR DESCRIPTION
Since this is a Maven plugin, we can reasonably expect that the user
already has configured maven correctly to reach Maven Central (or other
repositories) in some way. Therefore, instead of trying to deduce a way
to download our commandline tools from Maven settings, just ask Maven
kindly to do the download for us.

### Context

Since Allure has been available from Maven Central for quite a while, it should be less of a hassle for most users to just let Maven deal with the downloading of the command line artifact. The old code is still left as-is, but only gets used if the `allureDownloadUrl` is specified at all.

Additionally, this drops the embedded copy of allure-commandline, which makes this plugin quite a bit lighter.

*WARNING*: This breaks compatibility with Allure < 2.8.0 when not specifying `<allureDownloadUrl>https://dl.bintray.com/qameta/generic/io/qameta/allure/allure/%s/allure-%s.zip</allureDownloadUrl>` in the plugin configuration, but I consider this a minor problem, since that version is quite old nowadays.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests (existing ITs adapted to the new feature)

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
