### PR TITLE
Fix allure-maven plugin goalPrefix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
                     <artifactId>maven-plugin-plugin</artifactId>
                     <version>${maven-plugin.version}</version>
                     <configuration>
-                        <goalPrefix>prefix</goalPrefix>
+                        <goalPrefix>allure</goalPrefix>
                         <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                     </configuration>
                     <executions>


### PR DESCRIPTION
### Context
Since 2.15.0 it was changed from `allure` to `prefix`, so all `mvn allure:*` commands are not working since 2.15.0. Changing it back to `allure`

Fixes #337 

#### Checklist
- [ ] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
