### PR TITLE
Fix allure:aggregate failure in multi-module CLI builds

### DIFF
--- a/src/it/aggregate-multi-module-cli/first/pom.xml
+++ b/src/it/aggregate-multi-module-cli/first/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>allure-maven-it-first-child</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>Allure Report Test First Child</name>
+
+    <parent>
+        <groupId>io.qameta.allure-maven.it</groupId>
+        <artifactId>allure-maven-it</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+</project>

--- a/src/it/aggregate-multi-module-cli/first/target/allure-results/first-testsuite.xml
+++ b/src/it/aggregate-multi-module-cli/first/target/allure-results/first-testsuite.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ns2:test-suite xmlns:ns2="urn:model.allure.qatools.yandex.ru" start="1412949538848" stop="1412949560045"
+                version="1.4.4-SNAPSHOT">
+    <name>my.company.First</name>
+    <test-cases>
+        <test-case start="1412949539363" stop="1412949539730" status="passed">
+            <name>firstTestCase</name>
+        </test-case>
+    </test-cases>
+</ns2:test-suite>

--- a/src/it/aggregate-multi-module-cli/invoker.properties
+++ b/src/it/aggregate-multi-module-cli/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = -Dreport.version=2.30.0 verify allure:aggregate

--- a/src/it/aggregate-multi-module-cli/pom.xml
+++ b/src/it/aggregate-multi-module-cli/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.qameta.allure-maven.it</groupId>
+    <artifactId>allure-maven-it</artifactId>
+    <packaging>pom</packaging>
+    <version>1.0-SNAPSHOT</version>
+    <name>Allure Report Test</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
+    <modules>
+        <module>first</module>
+        <module>second</module>
+    </modules>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/it/aggregate-multi-module-cli/second/pom.xml
+++ b/src/it/aggregate-multi-module-cli/second/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>allure-maven-it-second-child</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>Allure Report Test Second Child</name>
+
+    <parent>
+        <groupId>io.qameta.allure-maven.it</groupId>
+        <artifactId>allure-maven-it</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+</project>

--- a/src/it/aggregate-multi-module-cli/second/target/allure-results/second-testsuite.xml
+++ b/src/it/aggregate-multi-module-cli/second/target/allure-results/second-testsuite.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ns2:test-suite xmlns:ns2="urn:model.allure.qatools.yandex.ru" start="1412949538848" stop="1412949560045"
+                version="1.4.4-SNAPSHOT">
+    <name>my.company.Second</name>
+    <test-cases>
+        <test-case start="1412949539363" stop="1412949539730" status="passed">
+            <name>secondTestCase</name>
+        </test-case>
+    </test-cases>
+</ns2:test-suite>

--- a/src/it/aggregate-multi-module-cli/verify.groovy
+++ b/src/it/aggregate-multi-module-cli/verify.groovy
@@ -1,0 +1,8 @@
+import java.nio.file.Paths
+
+import static io.qameta.allure.maven.TestHelper.checkReportDirectory
+
+def basedirPath = basedir.absolutePath
+def outputDirectory = Paths.get(basedirPath, 'target', 'site', 'allure-maven-plugin')
+
+checkReportDirectory(outputDirectory, 2)

--- a/src/main/java/io/qameta/allure/maven/AllureAggregateMojo.java
+++ b/src/main/java/io/qameta/allure/maven/AllureAggregateMojo.java
@@ -17,7 +17,6 @@ package io.qameta.allure.maven;
 
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
 import java.nio.file.Path;
@@ -34,10 +33,14 @@ import java.util.List;
 public class AllureAggregateMojo extends AllureGenerateMojo {
 
     /**
-     * The projects in the reactor.
+     * Normalize the inherited report parameter so direct CLI invocations can fall back at runtime
+     * instead of failing during configuration when Maven injects null here.
      */
-    @Parameter(defaultValue = "${reactorProjects}", required = true, readonly = true)
-    protected List<MavenProject> reactorProjects;
+    @SuppressWarnings("unused")
+    public void setReactorProjects(final List<MavenProject> reactorProjects) {
+        this.reactorProjects =
+                reactorProjects == null ? Collections.<MavenProject>emptyList() : reactorProjects;
+    }
 
     /**
      * {@inheritDoc}
@@ -50,8 +53,14 @@ public class AllureAggregateMojo extends AllureGenerateMojo {
             return Collections.emptyList();
         }
 
+        final List<MavenProject> projects = resolveReactorProjects();
+        if (projects.isEmpty()) {
+            getLog().warn("Reactor projects were not resolved for aggregate goal.");
+            return Collections.emptyList();
+        }
+
         final List<Path> result = new ArrayList<>();
-        for (MavenProject child : reactorProjects) {
+        for (MavenProject child : projects) {
             final Path target = Paths.get(child.getBuild().getDirectory());
             final Path path = target.resolve(relative).toAbsolutePath();
             if (isDirectoryExists(path)) {
@@ -63,6 +72,39 @@ public class AllureAggregateMojo extends AllureGenerateMojo {
         }
 
         return result;
+    }
+
+    protected List<MavenProject> resolveReactorProjects() {
+        final List<MavenProject> injectedProjects = getInjectedReactorProjects();
+        if (!injectedProjects.isEmpty()) {
+            return injectedProjects;
+        }
+
+        final List<MavenProject> sessionProjects = getSessionProjects();
+        if (!sessionProjects.isEmpty()) {
+            return sessionProjects;
+        }
+
+        final MavenProject currentProject = getProject();
+        if (currentProject != null) {
+            return Collections.singletonList(currentProject);
+        }
+
+        return Collections.emptyList();
+    }
+
+    protected List<MavenProject> getInjectedReactorProjects() {
+        if (reactorProjects == null) {
+            return Collections.emptyList();
+        }
+        return reactorProjects;
+    }
+
+    protected List<MavenProject> getSessionProjects() {
+        if (session == null || session.getProjects() == null) {
+            return Collections.emptyList();
+        }
+        return session.getProjects();
     }
 
     @Override

--- a/src/test/java/io/qameta/allure/maven/AllureAggregateMojoTest.java
+++ b/src/test/java/io/qameta/allure/maven/AllureAggregateMojoTest.java
@@ -1,0 +1,205 @@
+/*
+ *  Copyright 2016-2024 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.maven;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.maven.model.Build;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+
+public class AllureAggregateMojoTest {
+
+    @Test
+    public void shouldPreferInjectedReactorProjectsOverSessionProjects() throws Exception {
+        final Path workspace = Files.createTempDirectory("allure-aggregate-injected");
+        try {
+            final MavenProject injectedProject = createProject(workspace, "injected", "Injected");
+            final MavenProject sessionProject = createProject(workspace, "session", "Session");
+
+            final TestAggregateMojo mojo =
+                    new TestAggregateMojo(Collections.singletonList(sessionProject), null);
+            mojo.setReactorProjects(Collections.singletonList(injectedProject));
+
+            assertThat(mojo.getInputDirectories(), contains(resultsDirectory(injectedProject)));
+        } finally {
+            FileUtils.deleteQuietly(workspace.toFile());
+        }
+    }
+
+    @Test
+    public void shouldUseSessionProjectsWhenInjectedProjectsAreMissing() throws Exception {
+        final Path workspace = Files.createTempDirectory("allure-aggregate-session");
+        try {
+            final MavenProject sessionProject = createProject(workspace, "session", "Session");
+
+            final TestAggregateMojo mojo =
+                    new TestAggregateMojo(Collections.singletonList(sessionProject), null);
+
+            assertThat(mojo.getInputDirectories(), contains(resultsDirectory(sessionProject)));
+        } finally {
+            FileUtils.deleteQuietly(workspace.toFile());
+        }
+    }
+
+    @Test
+    public void shouldFallbackToCurrentProjectWhenReactorProjectsAreMissing() throws Exception {
+        final Path workspace = Files.createTempDirectory("allure-aggregate-project");
+        try {
+            final MavenProject currentProject = createProject(workspace, "current", "Current");
+
+            final TestAggregateMojo mojo =
+                    new TestAggregateMojo(Collections.<MavenProject>emptyList(), currentProject);
+
+            assertThat(mojo.getInputDirectories(), contains(resultsDirectory(currentProject)));
+        } finally {
+            FileUtils.deleteQuietly(workspace.toFile());
+        }
+    }
+
+    @Test
+    public void shouldWarnAndReturnEmptyListWhenNoProjectsAreAvailable() {
+        final RecordingLog log = new RecordingLog();
+        final TestAggregateMojo mojo =
+                new TestAggregateMojo(Collections.<MavenProject>emptyList(), null);
+        mojo.setLog(log);
+
+        assertThat(mojo.getInputDirectories(), is(empty()));
+        assertThat(log.warnMessages,
+                contains("Reactor projects were not resolved for aggregate " + "goal."));
+    }
+
+    private static MavenProject createProject(final Path workspace, final String directoryName,
+            final String projectName) throws Exception {
+        final Path projectDirectory = workspace.resolve(directoryName);
+        final Path buildDirectory = projectDirectory.resolve("target");
+        Files.createDirectories(buildDirectory.resolve("allure-results"));
+
+        final Build build = new Build();
+        build.setDirectory(buildDirectory.toString());
+
+        final MavenProject project = new MavenProject();
+        project.setName(projectName);
+        project.setBuild(build);
+        return project;
+    }
+
+    private static Path resultsDirectory(final MavenProject project) {
+        return Paths.get(project.getBuild().getDirectory(), "allure-results").toAbsolutePath();
+    }
+
+    private static final class TestAggregateMojo extends AllureAggregateMojo {
+
+        private final List<MavenProject> sessionProjects;
+        private final MavenProject currentProject;
+
+        private TestAggregateMojo(final List<MavenProject> sessionProjects,
+                final MavenProject currentProject) {
+            this.sessionProjects = sessionProjects;
+            this.currentProject = currentProject;
+            this.resultsDirectory = "allure-results";
+        }
+
+        @Override
+        protected List<MavenProject> getSessionProjects() {
+            return sessionProjects;
+        }
+
+        @Override
+        protected MavenProject getProject() {
+            return currentProject;
+        }
+    }
+
+    private static final class RecordingLog implements Log {
+
+        private final List<String> warnMessages = new ArrayList<String>();
+
+        @Override
+        public boolean isDebugEnabled() {
+            return false;
+        }
+
+        @Override
+        public void debug(final CharSequence content) {}
+
+        @Override
+        public void debug(final CharSequence content, final Throwable error) {}
+
+        @Override
+        public void debug(final Throwable error) {}
+
+        @Override
+        public boolean isInfoEnabled() {
+            return false;
+        }
+
+        @Override
+        public void info(final CharSequence content) {}
+
+        @Override
+        public void info(final CharSequence content, final Throwable error) {}
+
+        @Override
+        public void info(final Throwable error) {}
+
+        @Override
+        public boolean isWarnEnabled() {
+            return true;
+        }
+
+        @Override
+        public void warn(final CharSequence content) {
+            warnMessages.add(content.toString());
+        }
+
+        @Override
+        public void warn(final CharSequence content, final Throwable error) {
+            warn(content);
+        }
+
+        @Override
+        public void warn(final Throwable error) {
+            warn(error.getMessage());
+        }
+
+        @Override
+        public boolean isErrorEnabled() {
+            return false;
+        }
+
+        @Override
+        public void error(final CharSequence content) {}
+
+        @Override
+        public void error(final CharSequence content, final Throwable error) {}
+
+        @Override
+        public void error(final Throwable error) {}
+    }
+}


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

Fixes #405

allure:aggregate could fail in multi-module projects when it was run directly from the command line, for example:

mvn verify allure:aggregate

On newer Maven versions this could stop with reactorProjects cannot be null before the report was generated.

This change makes allure:aggregate fall back to the active Maven reactor from the current session when that project list is not injected up front.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2