### PR TITLE
Clarify mvn site output for aggregate Allure reports

### DIFF
--- a/src/it/aggregate-multi-module-exclude-report/verify.groovy
+++ b/src/it/aggregate-multi-module-exclude-report/verify.groovy
@@ -1,6 +1,9 @@
 import java.nio.file.Paths
 
+import static io.qameta.allure.maven.TestHelper.checkAggregateMojoOnly
 import static io.qameta.allure.maven.TestHelper.checkReportDirectory
+
+checkAggregateMojoOnly(Paths.get(basedir.absolutePath))
 
 def outputDirectory = Paths.get(basedir.absolutePath, 'target', 'site', 'allure-maven-plugin')
 checkReportDirectory(outputDirectory, 2)

--- a/src/it/aggregate-multi-module/verify.groovy
+++ b/src/it/aggregate-multi-module/verify.groovy
@@ -1,8 +1,11 @@
 import java.nio.file.Paths
 
+import static io.qameta.allure.maven.TestHelper.checkAggregateMojoOnly
 import static io.qameta.allure.maven.TestHelper.checkReportDirectory
 
 def basedirPath = basedir.absolutePath
+checkAggregateMojoOnly(Paths.get(basedirPath))
+
 def outputDirectory = Paths.get(basedirPath, 'target', 'site', 'allure-maven-plugin')
 
 checkReportDirectory(outputDirectory, 2)

--- a/src/it/aggregate-sample/verify.groovy
+++ b/src/it/aggregate-sample/verify.groovy
@@ -1,6 +1,9 @@
 import java.nio.file.Paths
 
+import static io.qameta.allure.maven.TestHelper.checkAggregateMojoOnly
 import static io.qameta.allure.maven.TestHelper.checkReportDirectory
+
+checkAggregateMojoOnly(Paths.get(basedir.absolutePath))
 
 def outputDirectory = Paths.get(basedir.absolutePath, 'target', 'site', 'allure-maven-plugin')
 checkReportDirectory(outputDirectory, 1)

--- a/src/it/allure3-aggregate-sample/verify.groovy
+++ b/src/it/allure3-aggregate-sample/verify.groovy
@@ -1,6 +1,7 @@
 import java.nio.file.Paths
 import java.nio.file.Files
 
+import static io.qameta.allure.maven.TestHelper.checkAggregateMojoOnly
 import static io.qameta.allure.maven.TestHelper.checkReportDirectory
 import static org.hamcrest.MatcherAssert.assertThat
 import static org.hamcrest.Matchers.is
@@ -11,6 +12,7 @@ def config = Paths.get(basedir.absolutePath, 'target', 'allure-maven', 'allure3'
 def results = Paths.get(basedir.absolutePath, 'target', 'allure-results')
 def allureCli = Paths.get(basedir.absolutePath, '.allure', 'allure-3.4.1', 'node_modules',
         'allure', 'cli.js').toAbsolutePath().toString()
+checkAggregateMojoOnly(Paths.get(basedir.absolutePath))
 checkReportDirectory(outputDirectory, 1)
 
 def args = Files.readAllLines(Paths.get(basedir.absolutePath, 'target',

--- a/src/it/allure3-config-path-plugin-property/verify.groovy
+++ b/src/it/allure3-config-path-plugin-property/verify.groovy
@@ -1,11 +1,14 @@
 import groovy.json.JsonSlurper
 import java.nio.file.Paths
 
+import static io.qameta.allure.maven.TestHelper.checkRegularReportMojoOnly
 import static org.hamcrest.MatcherAssert.assertThat
 import static org.hamcrest.Matchers.nullValue
 import static org.hamcrest.Matchers.is
 
 def basedirPath = basedir.absolutePath
+checkRegularReportMojoOnly(Paths.get(basedirPath))
+
 def config = new JsonSlurper().parse(Paths.get(basedirPath, 'target',
         'allure-maven', 'allure3', 'allurerc.json').toFile())
 

--- a/src/it/properties-file-support/verify.groovy
+++ b/src/it/properties-file-support/verify.groovy
@@ -2,10 +2,12 @@ import groovy.json.JsonSlurper
 
 import java.nio.file.Paths
 
+import static io.qameta.allure.maven.TestHelper.checkRegularReportMojoOnly
 import static io.qameta.allure.maven.TestHelper.checkReportDirectory
 import static io.qameta.allure.maven.TestHelper.getTestCases
 
 def outputDirectory = Paths.get(basedir.absolutePath, 'target', 'site', 'allure-maven-plugin')
+checkRegularReportMojoOnly(Paths.get(basedir.absolutePath))
 checkReportDirectory(outputDirectory, 1)
 
 def dataDirectory = outputDirectory.resolve('data')

--- a/src/main/java/io/qameta/allure/maven/AllureGenerateMojo.java
+++ b/src/main/java/io/qameta/allure/maven/AllureGenerateMojo.java
@@ -190,7 +190,6 @@ public abstract class AllureGenerateMojo extends AllureBaseMojo {
 
             getLog().info(String.format("Generate Allure report (%s) with version %s",
                     getMojoName(), allureVersion.getVersion()));
-            getLog().info("Generate Allure report to " + getReportDirectory());
 
             final List<Path> inputDirectories = getInputDirectories();
 

--- a/src/test/java/io/qameta/allure/maven/TestHelper.java
+++ b/src/test/java/io/qameta/allure/maven/TestHelper.java
@@ -98,14 +98,13 @@ public final class TestHelper {
         assertThat(content, not(containsString("Generate Allure report (aggregate)")));
         assertThat(content, not(containsString("Generate Allure report to ")));
         assertThat(countMatches(content,
-                "^\\[INFO\\] Generate Allure report \\(report\\) with version ",
-                Pattern.MULTILINE), is(1));
+                "^\\[INFO\\] Generate Allure report \\(report\\) with version ", Pattern.MULTILINE),
+                is(1));
         assertThat(countMatches(content, "^\\[INFO\\] Generate report to ", Pattern.MULTILINE),
                 is(1));
     }
 
-    private static int countMatches(final String content, final String pattern,
-            final int flags) {
+    private static int countMatches(final String content, final String pattern, final int flags) {
         final Matcher matcher = Pattern.compile(pattern, flags).matcher(content);
         int count = 0;
         while (matcher.find()) {

--- a/src/test/java/io/qameta/allure/maven/TestHelper.java
+++ b/src/test/java/io/qameta/allure/maven/TestHelper.java
@@ -89,6 +89,21 @@ public final class TestHelper {
                 is(1));
     }
 
+    public static void checkRegularReportMojoOnly(Path projectDirectory) throws IOException {
+        final Path buildLog = projectDirectory.resolve("build.log");
+        assertThat(buildLog, exists());
+
+        final String content = Files.readString(buildLog, StandardCharsets.UTF_8);
+        assertThat(content, containsString("Generate Allure report (report)"));
+        assertThat(content, not(containsString("Generate Allure report (aggregate)")));
+        assertThat(content, not(containsString("Generate Allure report to ")));
+        assertThat(countMatches(content,
+                "^\\[INFO\\] Generate Allure report \\(report\\) with version ",
+                Pattern.MULTILINE), is(1));
+        assertThat(countMatches(content, "^\\[INFO\\] Generate report to ", Pattern.MULTILINE),
+                is(1));
+    }
+
     private static int countMatches(final String content, final String pattern,
             final int flags) {
         final Matcher matcher = Pattern.compile(pattern, flags).matcher(content);

--- a/src/test/java/io/qameta/allure/maven/TestHelper.java
+++ b/src/test/java/io/qameta/allure/maven/TestHelper.java
@@ -17,11 +17,18 @@ package io.qameta.allure.maven;
 
 import org.apache.commons.io.filefilter.WildcardFileFilter;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static ru.yandex.qatools.matchers.nio.PathMatchers.exists;
@@ -68,5 +75,27 @@ public final class TestHelper {
 
     public static List<String> getTestCases(Path dataDirectory) {
         return Arrays.asList(dataDirectory.toFile().list(new WildcardFileFilter("*.json")));
+    }
+
+    public static void checkAggregateMojoOnly(Path projectDirectory) throws IOException {
+        final Path buildLog = projectDirectory.resolve("build.log");
+        assertThat(buildLog, exists());
+
+        final String content = Files.readString(buildLog, StandardCharsets.UTF_8);
+        assertThat(content, containsString("Generate Allure report (aggregate)"));
+        assertThat(content, not(containsString("Generate Allure report (report)")));
+        assertThat(content, not(containsString("Generate Allure report to ")));
+        assertThat(countMatches(content, "^\\[INFO\\] Generate report to ", Pattern.MULTILINE),
+                is(1));
+    }
+
+    private static int countMatches(final String content, final String pattern,
+            final int flags) {
+        final Matcher matcher = Pattern.compile(pattern, flags).matcher(content);
+        int count = 0;
+        while (matcher.find()) {
+            count++;
+        }
+        return count;
     }
 }


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->
When a project is configured to generate only the aggregate Allure report, ./mvn site printed two near-identical “generate report” messages for the same output directory.

That made the build output look like the report was being generated twice, or like both the regular and aggregate reports were running, even though only the aggregate report was executed.

This change removes the redundant log message so the site output reflects a single aggregate report generation flow more clearly.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2