### PR TITLE
Preserve generated report when running allure:report and allure:serve together

### DIFF
--- a/src/it/allure2-report-then-serve-preserves-report-directory/invoker.properties
+++ b/src/it/allure2-report-then-serve-preserves-report-directory/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = -Dmaven.repo.local=target/it-local-repo allure:report allure:serve

--- a/src/it/allure2-report-then-serve-preserves-report-directory/pom.xml
+++ b/src/it/allure2-report-then-serve-preserves-report-directory/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.qameta.allure-maven.it</groupId>
+    <artifactId>allure-maven-it</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>Allure Report Then Serve Preserves Report Directory Test</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <installDirectory>${project.basedir}/.allure install</installDirectory>
+                    <reportDirectory>${project.build.directory}/site/preserved-report</reportDirectory>
+                    <reportVersion>2.30.0</reportVersion>
+                    <serveTimeout>10</serveTimeout>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/it/allure2-report-then-serve-preserves-report-directory/setup.groovy
+++ b/src/it/allure2-report-then-serve-preserves-report-directory/setup.groovy
@@ -1,0 +1,108 @@
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.StandardCopyOption
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+def version = '2.30.0'
+def localRepository = Paths.get(basedir.absolutePath, 'target', 'it-local-repo')
+def sharedRepository = localRepositoryPath.toPath()
+copyRecursively(
+        sharedRepository.resolve(Paths.get('io', 'qameta', 'allure', 'allure-maven')),
+        localRepository.resolve(Paths.get('io', 'qameta', 'allure', 'allure-maven'))
+)
+
+def artifactDirectory = localRepository
+        .resolve(Paths.get('io', 'qameta', 'allure', 'allure-commandline', version))
+Files.createDirectories(artifactDirectory)
+
+def zipPath = artifactDirectory.resolve("allure-commandline-${version}.zip")
+def pomPath = artifactDirectory.resolve("allure-commandline-${version}.pom")
+def captureFile = Paths.get(basedir.absolutePath, 'target', 'captured commands.txt').toAbsolutePath()
+def captureDirectory = captureFile.getParent().toAbsolutePath()
+def reportDirectory = Paths.get(basedir.absolutePath, 'target', 'site', 'preserved-report')
+        .toAbsolutePath()
+
+Files.write(pomPath, """\
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>io.qameta.allure</groupId>
+    <artifactId>allure-commandline</artifactId>
+    <version>${version}</version>
+    <packaging>zip</packaging>
+</project>
+""".stripIndent().getBytes(StandardCharsets.UTF_8))
+
+def unixLauncher = [
+        '#!/bin/sh',
+        'set -eu',
+        'command="$1"',
+        "mkdir -p \"${captureDirectory}\"",
+        "touch \"${captureFile}\"",
+        "printf 'command=%s\\n' \"\$command\" >> \"${captureFile}\"",
+        'for arg in "$@"; do',
+        "  printf 'arg=%s\\n' \"\$arg\" >> \"${captureFile}\"",
+        'done',
+        "printf '%s\\n' '---' >> \"${captureFile}\"",
+        'if [ "$command" = "generate" ]; then',
+        "  mkdir -p \"${reportDirectory}\"",
+        "  : > \"${reportDirectory.resolve('index.html')}\"",
+        'fi',
+        'exit 0',
+        ''
+].join('\n')
+
+def windowsLauncher = [
+        '@echo off',
+        'setlocal EnableExtensions DisableDelayedExpansion',
+        "if not exist \"${captureDirectory}\" mkdir \"${captureDirectory}\"",
+        "if not exist \"${captureFile}\" type nul > \"${captureFile}\"",
+        'set "COMMAND=%~1"',
+        ">> \"${captureFile}\" echo(command=%COMMAND%",
+        ':loop',
+        'if "%~1"=="" goto done',
+        ">> \"${captureFile}\" echo(arg=%~1",
+        'shift',
+        'goto loop',
+        ':done',
+        ">> \"${captureFile}\" echo(---",
+        'if /I not "%COMMAND%"=="generate" exit /b 0',
+        "if not exist \"${reportDirectory}\" mkdir \"${reportDirectory}\"",
+        "type nul > \"${reportDirectory.resolve('index.html')}\"",
+        'exit /b 0',
+        ''
+].join('\r\n')
+
+def zip = new ZipOutputStream(Files.newOutputStream(zipPath))
+try {
+    addZipEntry(zip, "allure-${version}/bin/allure", unixLauncher)
+    addZipEntry(zip, "allure-${version}/bin/allure.bat", windowsLauncher)
+} finally {
+    zip.close()
+}
+
+static void addZipEntry(final ZipOutputStream zip, final String name, final String content) {
+    zip.putNextEntry(new ZipEntry(name))
+    zip.write(content.getBytes(StandardCharsets.UTF_8))
+    zip.closeEntry()
+}
+
+static void copyRecursively(final Path source, final Path target) {
+    if (!Files.exists(source)) {
+        return
+    }
+    Files.walk(source).forEach { path ->
+        def relative = source.relativize(path)
+        def destination = target.resolve(relative.toString())
+        if (Files.isDirectory(path)) {
+            Files.createDirectories(destination)
+        } else {
+            Files.createDirectories(destination.getParent())
+            Files.copy(path, destination, StandardCopyOption.REPLACE_EXISTING)
+        }
+    }
+}

--- a/src/it/allure2-report-then-serve-preserves-report-directory/target/allure-results/sample-testsuite.xml
+++ b/src/it/allure2-report-then-serve-preserves-report-directory/target/allure-results/sample-testsuite.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ns2:test-suite xmlns:ns2="urn:model.allure.qatools.yandex.ru" start="1412949538848" stop="1412949560045"
+                version="1.4.4-SNAPSHOT">
+    <name>my.company.Sample</name>
+    <test-cases>
+        <test-case start="1412949539363" stop="1412949539730" status="passed">
+            <name>sampleTestCase</name>
+        </test-case>
+    </test-cases>
+</ns2:test-suite>

--- a/src/it/allure2-report-then-serve-preserves-report-directory/verify.groovy
+++ b/src/it/allure2-report-then-serve-preserves-report-directory/verify.groovy
@@ -1,0 +1,20 @@
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Paths
+
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.Matchers.is
+import static ru.yandex.qatools.matchers.nio.PathMatchers.exists
+
+def capturedCommands = Paths.get(basedir.absolutePath, 'target', 'captured commands.txt')
+def resultsDirectory = Paths.get(basedir.absolutePath, 'target', 'allure-results')
+def reportDirectory = Paths.get(basedir.absolutePath, 'target', 'site', 'preserved-report')
+
+def expected = ['command=generate', 'arg=generate', 'arg=--clean',
+                "arg=${resultsDirectory.toAbsolutePath()}", 'arg=-o',
+                "arg=${reportDirectory.toAbsolutePath()}", '---',
+                'command=serve', 'arg=serve', "arg=${resultsDirectory.toAbsolutePath()}",
+                '---'].collect { it.toString() }
+
+assertThat(Files.readAllLines(capturedCommands, StandardCharsets.UTF_8), is(expected))
+assertThat(reportDirectory.resolve('index.html'), exists())

--- a/src/main/java/io/qameta/allure/maven/AllureCommandline.java
+++ b/src/main/java/io/qameta/allure/maven/AllureCommandline.java
@@ -98,12 +98,10 @@ public class AllureCommandline {
         return execute(commandLine, timeout);
     }
 
-    public int serve(final List<Path> resultsPaths, final Path reportPath, final String serveHost,
-            final Integer servePort) throws IOException {
+    public int serve(final List<Path> resultsPaths, final String serveHost, final Integer servePort)
+            throws IOException {
 
         this.checkAllureExists();
-
-        FileUtils.deleteQuietly(reportPath.toFile());
 
         final CommandLine commandLine =
                 new CommandLine(getAllureExecutablePath().toAbsolutePath().toFile());

--- a/src/main/java/io/qameta/allure/maven/AllureServeMojo.java
+++ b/src/main/java/io/qameta/allure/maven/AllureServeMojo.java
@@ -84,15 +84,13 @@ public class AllureServeMojo extends AllureGenerateMojo {
     private void serveAllure2(final List<Path> resultsPaths, final AllureVersion allureVersion)
             throws MavenReportException {
         try {
-            final Path reportPath = Paths.get(getReportDirectory());
-
             final AllureCommandline commandline =
                     new AllureCommandline(Paths.get(getInstallDirectory()),
                             allureVersion.getVersion(), this.serveTimeout);
 
-            getLog().info("Generate report to " + reportPath);
-            commandline.serve(resultsPaths, reportPath, this.serveHost, this.servePort);
-            getLog().info("Report generated successfully.");
+            getLog().info("Serve Allure report using a temporary directory managed by the CLI.");
+            commandline.serve(resultsPaths, this.serveHost, this.servePort);
+            getLog().info("Report served successfully.");
         } catch (Exception e) {
             getLog().error("Generate error", e);
             throw new MavenReportException("Can't generate allure report", e);

--- a/src/test/java/io/qameta/allure/maven/AllureCommandlineTest.java
+++ b/src/test/java/io/qameta/allure/maven/AllureCommandlineTest.java
@@ -143,7 +143,6 @@ public class AllureCommandlineTest {
             final String version = "2.30.0";
             final Path installDirectory = testDirectory.resolve("install with space");
             final Path resultsDirectory = testDirectory.resolve("results with space");
-            final Path reportDirectory = testDirectory.resolve("report with space");
             final Path capturedArgs = testDirectory.resolve("captured args.txt");
             Files.createDirectories(resultsDirectory);
 
@@ -155,8 +154,7 @@ public class AllureCommandlineTest {
 
             final AllureCommandline commandline = new AllureCommandline(installDirectory, version);
             commandline.download(url, null, new Properties());
-            commandline.serve(Collections.singletonList(resultsDirectory), reportDirectory, null,
-                    0);
+            commandline.serve(Collections.singletonList(resultsDirectory), null, 0);
 
             assertThat(Files.readAllLines(capturedArgs, StandardCharsets.UTF_8),
                     is(Arrays.asList("serve", resultsDirectory.toAbsolutePath().toString())));


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

Running mvn allure:report allure:serve could remove the report that was just generated in target/site, even though allure:serve opens a temporary report and does not need to clean the saved one.

This change keeps the generated report in place when allure:serve runs after allure:report

Fixes #139 

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2