### PR TITLE
Fix wrong executor names in aggregated multi-module reports

### DIFF
--- a/src/it/aggregate-multi-module-preserve-child-executor/first/pom.xml
+++ b/src/it/aggregate-multi-module-preserve-child-executor/first/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>allure-maven-it-first-child</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>Allure Report Test First Child</name>
+
+    <parent>
+        <groupId>io.qameta.allure-maven.it</groupId>
+        <artifactId>allure-maven-it</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <reporting>
+        <excludeDefaults>true</excludeDefaults>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <reportVersion>2.30.0</reportVersion>
+                </configuration>
+            </plugin>
+        </plugins>
+    </reporting>
+
+</project>

--- a/src/it/aggregate-multi-module-preserve-child-executor/first/target/allure-results/first-testsuite.xml
+++ b/src/it/aggregate-multi-module-preserve-child-executor/first/target/allure-results/first-testsuite.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ns2:test-suite xmlns:ns2="urn:model.allure.qatools.yandex.ru" start="1412949538848" stop="1412949560045"
+                version="1.4.4-SNAPSHOT">
+    <name>my.company.First</name>
+    <test-cases>
+        <test-case start="1412949539363" stop="1412949539730" status="passed">
+            <name>firstTestCase</name>
+        </test-case>
+    </test-cases>
+</ns2:test-suite>

--- a/src/it/aggregate-multi-module-preserve-child-executor/pom.xml
+++ b/src/it/aggregate-multi-module-preserve-child-executor/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.qameta.allure-maven.it</groupId>
+    <artifactId>allure-maven-it</artifactId>
+    <packaging>pom</packaging>
+    <version>1.0-SNAPSHOT</version>
+    <name>Allure Aggregate Preserve Executor Test</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
+    <modules>
+        <module>first</module>
+        <module>second</module>
+    </modules>
+
+    <reporting>
+        <excludeDefaults>true</excludeDefaults>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <reportSets>
+                    <reportSet>
+                        <id>aggregate</id>
+                        <inherited>false</inherited>
+                        <reports>
+                            <report>aggregate</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+                <configuration>
+                    <reportVersion>2.30.0</reportVersion>
+                </configuration>
+            </plugin>
+        </plugins>
+    </reporting>
+
+</project>

--- a/src/it/aggregate-multi-module-preserve-child-executor/second/pom.xml
+++ b/src/it/aggregate-multi-module-preserve-child-executor/second/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>allure-maven-it-second-child</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>Allure Report Test Second Child</name>
+
+    <parent>
+        <groupId>io.qameta.allure-maven.it</groupId>
+        <artifactId>allure-maven-it</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <reporting>
+        <excludeDefaults>true</excludeDefaults>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <reportVersion>2.30.0</reportVersion>
+                </configuration>
+            </plugin>
+        </plugins>
+    </reporting>
+
+</project>

--- a/src/it/aggregate-multi-module-preserve-child-executor/second/target/allure-results/second-testsuite.xml
+++ b/src/it/aggregate-multi-module-preserve-child-executor/second/target/allure-results/second-testsuite.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ns2:test-suite xmlns:ns2="urn:model.allure.qatools.yandex.ru" start="1412949538848" stop="1412949560045"
+                version="1.4.4-SNAPSHOT">
+    <name>my.company.Second</name>
+    <test-cases>
+        <test-case start="1412949539363" stop="1412949539730" status="passed">
+            <name>secondTestCase</name>
+        </test-case>
+    </test-cases>
+</ns2:test-suite>

--- a/src/it/aggregate-multi-module-preserve-child-executor/verify.groovy
+++ b/src/it/aggregate-multi-module-preserve-child-executor/verify.groovy
@@ -1,0 +1,20 @@
+import groovy.json.JsonSlurper
+
+import java.nio.file.Files
+import java.nio.file.Paths
+
+import static io.qameta.allure.maven.TestHelper.checkReportDirectory
+
+def basedirPath = basedir.absolutePath
+def outputDirectory = Paths.get(basedirPath, 'target', 'site', 'allure-maven-plugin')
+
+checkReportDirectory(outputDirectory, 2)
+
+def slurper = new JsonSlurper()
+def firstExecutor = Paths.get(basedirPath, 'first', 'target', 'allure-results', 'executor.json')
+def secondExecutor = Paths.get(basedirPath, 'second', 'target', 'allure-results', 'executor.json')
+
+assert Files.exists(firstExecutor)
+assert Files.exists(secondExecutor)
+assert slurper.parse(firstExecutor.toFile()).buildName == 'Allure Report Test First Child'
+assert slurper.parse(secondExecutor.toFile()).buildName == 'Allure Report Test Second Child'

--- a/src/main/java/io/qameta/allure/maven/AllureAggregateMojo.java
+++ b/src/main/java/io/qameta/allure/maven/AllureAggregateMojo.java
@@ -108,6 +108,30 @@ public class AllureAggregateMojo extends AllureGenerateMojo {
     }
 
     @Override
+    protected List<Path> getExecutorInfoDirectories(final List<Path> inputDirectories) {
+        final MavenProject currentProject = getProject();
+        if (currentProject == null || currentProject.getBuild() == null
+                || currentProject.getBuild().getDirectory() == null) {
+            return Collections.emptyList();
+        }
+
+        final Path relative = Paths.get(resultsDirectory);
+        if (relative.isAbsolute()) {
+            return Collections.emptyList();
+        }
+
+        final Path currentResultsDirectory = Paths.get(currentProject.getBuild().getDirectory())
+                .resolve(relative).toAbsolutePath().normalize();
+        for (Path inputDirectory : inputDirectories) {
+            if (inputDirectory.toAbsolutePath().normalize().equals(currentResultsDirectory)) {
+                return Collections.singletonList(inputDirectory);
+            }
+        }
+
+        return Collections.emptyList();
+    }
+
+    @Override
     protected String getMojoName() {
         return "aggregate";
     }

--- a/src/main/java/io/qameta/allure/maven/AllureGenerateMojo.java
+++ b/src/main/java/io/qameta/allure/maven/AllureGenerateMojo.java
@@ -211,16 +211,20 @@ public abstract class AllureGenerateMojo extends AllureBaseMojo {
         }
     }
 
-    private void copyExecutorInfo(final List<Path> inputDirectories) throws IOException {
+    protected void copyExecutorInfo(final List<Path> inputDirectories) throws IOException {
         addPropertyIfAbsent("name", "Maven");
         addPropertyIfAbsent("type", "maven");
         addPropertyIfAbsent("buildName", getProject() == null ? "N/A" : getProject().getName());
 
         final ObjectMapper mapper = new ObjectMapper();
-        for (Path dir : inputDirectories) {
+        for (Path dir : getExecutorInfoDirectories(inputDirectories)) {
             final Path executorInfoFile = dir.resolve("executor.json");
             mapper.writeValue(executorInfoFile.toFile(), executorInfo);
         }
+    }
+
+    protected List<Path> getExecutorInfoDirectories(final List<Path> inputDirectories) {
+        return inputDirectories;
     }
 
     private void addPropertyIfAbsent(final String key, final String value) {

--- a/src/test/java/io/qameta/allure/maven/AllureAggregateMojoTest.java
+++ b/src/test/java/io/qameta/allure/maven/AllureAggregateMojoTest.java
@@ -15,6 +15,8 @@
  */
 package io.qameta.allure.maven;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.model.Build;
 import org.apache.maven.plugin.logging.Log;
@@ -25,6 +27,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -34,6 +37,8 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 
 public class AllureAggregateMojoTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @Test
     public void shouldPreferInjectedReactorProjectsOverSessionProjects() throws Exception {
@@ -94,6 +99,66 @@ public class AllureAggregateMojoTest {
                 contains("Reactor projects were not resolved for aggregate " + "goal."));
     }
 
+    @Test
+    public void shouldPreserveChildExecutorInfoWhenAggregating() throws Exception {
+        final Path workspace = Files.createTempDirectory("allure-aggregate-executor");
+        try {
+            final MavenProject currentProject = createProject(workspace, "current", "Current");
+            final MavenProject childProject = createProject(workspace, "child", "Child");
+            final Path currentResultsDirectory = resultsDirectory(currentProject);
+            final Path childResultsDirectory = resultsDirectory(childProject);
+            final Path childExecutor = childResultsDirectory.resolve("executor.json");
+
+            Files.writeString(currentResultsDirectory.resolve("executor.json"),
+                    "{\"buildName\":\"Old\"}");
+            Files.writeString(childExecutor,
+                    "{\"buildName\":\"Child\",\"name\":\"Existing\",\"type\":\"custom\"}");
+
+            final TestAggregateMojo mojo = new TestAggregateMojo(
+                    Arrays.asList(currentProject, childProject), currentProject);
+            final List<Path> inputDirectories =
+                    Arrays.asList(currentResultsDirectory, childResultsDirectory);
+
+            assertThat(mojo.executorInfoDirectoriesFrom(inputDirectories),
+                    contains(currentResultsDirectory));
+
+            mojo.copyExecutorInfoTo(inputDirectories);
+
+            final JsonNode currentExecutorInfo = OBJECT_MAPPER
+                    .readTree(currentResultsDirectory.resolve("executor.json").toFile());
+            assertThat(currentExecutorInfo.get("buildName").asText(), is("Current"));
+            assertThat(currentExecutorInfo.get("name").asText(), is("Maven"));
+            assertThat(currentExecutorInfo.get("type").asText(), is("maven"));
+
+            final JsonNode childExecutorInfo = OBJECT_MAPPER.readTree(childExecutor.toFile());
+            assertThat(childExecutorInfo.get("buildName").asText(), is("Child"));
+            assertThat(childExecutorInfo.get("name").asText(), is("Existing"));
+            assertThat(childExecutorInfo.get("type").asText(), is("custom"));
+        } finally {
+            FileUtils.deleteQuietly(workspace.toFile());
+        }
+    }
+
+    @Test
+    public void shouldSkipExecutorInfoWhenCurrentModuleResultsAreNotInAggregateInputs()
+            throws Exception {
+        final Path workspace = Files.createTempDirectory("allure-aggregate-executor-missing");
+        try {
+            final MavenProject currentProject = createProject(workspace, "current", "Current");
+            final MavenProject childProject = createProject(workspace, "child", "Child");
+
+            final TestAggregateMojo mojo =
+                    new TestAggregateMojo(Collections.singletonList(childProject), currentProject);
+
+            assertThat(
+                    mojo.executorInfoDirectoriesFrom(
+                            Collections.singletonList(resultsDirectory(childProject))),
+                    is(empty()));
+        } finally {
+            FileUtils.deleteQuietly(workspace.toFile());
+        }
+    }
+
     private static MavenProject createProject(final Path workspace, final String directoryName,
             final String projectName) throws Exception {
         final Path projectDirectory = workspace.resolve(directoryName);
@@ -133,6 +198,14 @@ public class AllureAggregateMojoTest {
         @Override
         protected MavenProject getProject() {
             return currentProject;
+        }
+
+        private List<Path> executorInfoDirectoriesFrom(final List<Path> inputDirectories) {
+            return getExecutorInfoDirectories(inputDirectories);
+        }
+
+        private void copyExecutorInfoTo(final List<Path> inputDirectories) throws Exception {
+            copyExecutorInfo(inputDirectories);
         }
     }
 


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->


When generating an aggregate report for a multi-module Maven build, child modules could show the parent module name in the Executor section.

That made the aggregated report confusing, because results from different modules looked like they came from the same place.

Aggregate report generation now keeps the executor information created by each child module instead of replacing it with the parent module name.

Fixes #55

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2