### PR TITLE
Fix allure:aggregate for multi-module builds with custom results directories

### DIFF
--- a/src/it/allure3-aggregate-multi-module-results-directory/first/pom.xml
+++ b/src/it/allure3-aggregate-multi-module-results-directory/first/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>allure-maven-it-first-child</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>Allure Aggregate Results Directory First Child</name>
+
+    <parent>
+        <groupId>io.qameta.allure-maven.it</groupId>
+        <artifactId>allure-maven-it</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+</project>

--- a/src/it/allure3-aggregate-multi-module-results-directory/first/target/module-results/first-testsuite.xml
+++ b/src/it/allure3-aggregate-multi-module-results-directory/first/target/module-results/first-testsuite.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ns2:test-suite xmlns:ns2="urn:model.allure.qatools.yandex.ru" start="1412949538848" stop="1412949560045"
+                version="1.4.4-SNAPSHOT">
+    <name>my.company.First</name>
+    <test-cases>
+        <test-case start="1412949539363" stop="1412949539730" status="passed">
+            <name>firstTestCase</name>
+        </test-case>
+    </test-cases>
+</ns2:test-suite>

--- a/src/it/allure3-aggregate-multi-module-results-directory/pom.xml
+++ b/src/it/allure3-aggregate-multi-module-results-directory/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.qameta.allure-maven.it</groupId>
+    <artifactId>allure-maven-it</artifactId>
+    <packaging>pom</packaging>
+    <version>1.0-SNAPSHOT</version>
+    <name>Allure Aggregate Results Directory Test</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
+    <modules>
+        <module>first</module>
+        <module>second</module>
+    </modules>
+
+    <reporting>
+        <excludeDefaults>true</excludeDefaults>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <reportSets>
+                    <reportSet>
+                        <id>aggregate</id>
+                        <inherited>true</inherited>
+                        <reports>
+                            <report>aggregate</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+                <configuration>
+                    <resultsDirectory>module-results</resultsDirectory>
+                </configuration>
+            </plugin>
+        </plugins>
+    </reporting>
+
+</project>

--- a/src/it/allure3-aggregate-multi-module-results-directory/second/pom.xml
+++ b/src/it/allure3-aggregate-multi-module-results-directory/second/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>allure-maven-it-second-child</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>Allure Aggregate Results Directory Second Child</name>
+
+    <parent>
+        <groupId>io.qameta.allure-maven.it</groupId>
+        <artifactId>allure-maven-it</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <properties>
+        <allure.results.directory>override-results</allure.results.directory>
+    </properties>
+
+</project>

--- a/src/it/allure3-aggregate-multi-module-results-directory/second/target/override-results/second-testsuite.xml
+++ b/src/it/allure3-aggregate-multi-module-results-directory/second/target/override-results/second-testsuite.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ns2:test-suite xmlns:ns2="urn:model.allure.qatools.yandex.ru" start="1412949538848" stop="1412949560045"
+                version="1.4.4-SNAPSHOT">
+    <name>my.company.Second</name>
+    <test-cases>
+        <test-case start="1412949539363" stop="1412949539730" status="passed">
+            <name>secondTestCase</name>
+        </test-case>
+    </test-cases>
+</ns2:test-suite>

--- a/src/it/allure3-aggregate-multi-module-results-directory/setup.groovy
+++ b/src/it/allure3-aggregate-multi-module-results-directory/setup.groovy
@@ -1,0 +1,11 @@
+import java.nio.file.Paths
+
+import static io.qameta.allure.maven.Allure3SetupHelper.prepareFakeReportRuntime
+
+def basedirPath = basedir.toPath().toAbsolutePath()
+prepareFakeReportRuntime(
+        basedirPath.resolve('.allure'),
+        basedirPath.resolve(Paths.get('target', 'allure3 aggregate results args.txt')),
+        basedirPath.resolve(Paths.get('target', 'site', 'allure-maven-plugin')),
+        true
+)

--- a/src/it/allure3-aggregate-multi-module-results-directory/verify.groovy
+++ b/src/it/allure3-aggregate-multi-module-results-directory/verify.groovy
@@ -1,0 +1,27 @@
+import java.nio.file.Files
+import java.nio.file.Paths
+
+import static io.qameta.allure.maven.TestHelper.checkAggregateMojoOnly
+import static io.qameta.allure.maven.TestHelper.checkReportDirectory
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.Matchers.is
+
+def basedirPath = basedir.absolutePath
+def outputDirectory = Paths.get(basedirPath, 'target', 'site', 'allure-maven-plugin')
+def config = Paths.get(basedirPath, 'target', 'allure-maven', 'allure3', 'allurerc.json')
+def firstResults = Paths.get(basedirPath, 'first', 'target', 'module-results')
+def secondResults = Paths.get(basedirPath, 'second', 'target', 'override-results')
+def allureCli = Paths.get(basedirPath, '.allure', 'allure-3.4.1', 'node_modules', 'allure',
+        'cli.js').toAbsolutePath().toString()
+
+checkAggregateMojoOnly(Paths.get(basedirPath))
+checkReportDirectory(outputDirectory, 1)
+
+def args = Files.readAllLines(Paths.get(basedirPath, 'target',
+        'allure3 aggregate results args.txt'))
+def expected = [ "cli=${allureCli}", 'command=generate', 'arg=generate',
+        "arg=${firstResults.toAbsolutePath()}", "arg=${secondResults.toAbsolutePath()}",
+        'arg=--config', "arg=${config.toAbsolutePath()}", '---' ].collect {
+    it.toString()
+}
+assertThat(args, is(expected))

--- a/src/main/java/io/qameta/allure/maven/AllureAggregateMojo.java
+++ b/src/main/java/io/qameta/allure/maven/AllureAggregateMojo.java
@@ -15,10 +15,12 @@
  */
 package io.qameta.allure.maven;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.project.MavenProject;
 
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -30,7 +32,14 @@ import java.util.List;
  */
 @Mojo(name = "aggregate", defaultPhase = LifecyclePhase.SITE, inheritByDefault = false,
         aggregator = true)
+@SuppressWarnings("PMD.GodClass")
 public class AllureAggregateMojo extends AllureGenerateMojo {
+
+    private static final String MODULE_RESULTS_DIRECTORY_PREFIX = "Results directory for module ";
+
+    private static final String RESULTS_DIRECTORY_PROPERTY = "allure.results.directory";
+
+    private static final String UNAVAILABLE_PROJECT_LABEL = "N/A";
 
     /**
      * Normalize the inherited report parameter so direct CLI invocations can fall back at runtime
@@ -47,12 +56,6 @@ public class AllureAggregateMojo extends AllureGenerateMojo {
      */
     @Override
     protected List<Path> getInputDirectories() {
-        final Path relative = Paths.get(resultsDirectory);
-        if (relative.isAbsolute()) {
-            getLog().error("Input directory should be not absolute for aggregate goal.");
-            return Collections.emptyList();
-        }
-
         final List<MavenProject> projects = resolveReactorProjects();
         if (projects.isEmpty()) {
             getLog().warn("Reactor projects were not resolved for aggregate goal.");
@@ -61,13 +64,15 @@ public class AllureAggregateMojo extends AllureGenerateMojo {
 
         final List<Path> result = new ArrayList<>();
         for (MavenProject child : projects) {
-            final Path target = Paths.get(child.getBuild().getDirectory());
-            final Path path = target.resolve(relative).toAbsolutePath();
+            final Path path = resolveResultsDirectory(child, true);
+            if (path == null) {
+                continue;
+            }
             if (isDirectoryExists(path)) {
                 result.add(path);
                 getLog().info("Found results directory " + path);
             } else {
-                getLog().warn("Results directory for module " + child.getName() + " not found.");
+                getLog().warn(MODULE_RESULTS_DIRECTORY_PREFIX + child.getName() + " not found.");
             }
         }
 
@@ -110,18 +115,15 @@ public class AllureAggregateMojo extends AllureGenerateMojo {
     @Override
     protected List<Path> getExecutorInfoDirectories(final List<Path> inputDirectories) {
         final MavenProject currentProject = getProject();
-        if (currentProject == null || currentProject.getBuild() == null
-                || currentProject.getBuild().getDirectory() == null) {
+        if (currentProject == null) {
             return Collections.emptyList();
         }
 
-        final Path relative = Paths.get(resultsDirectory);
-        if (relative.isAbsolute()) {
+        final Path currentResultsDirectory = resolveResultsDirectory(currentProject, false);
+        if (currentResultsDirectory == null) {
             return Collections.emptyList();
         }
 
-        final Path currentResultsDirectory = Paths.get(currentProject.getBuild().getDirectory())
-                .resolve(relative).toAbsolutePath().normalize();
         for (Path inputDirectory : inputDirectories) {
             if (inputDirectory.toAbsolutePath().normalize().equals(currentResultsDirectory)) {
                 return Collections.singletonList(inputDirectory);
@@ -139,6 +141,112 @@ public class AllureAggregateMojo extends AllureGenerateMojo {
     @Override
     protected boolean isAggregate() {
         return true;
+    }
+
+    protected Path resolveResultsDirectory(final MavenProject project) {
+        return resolveResultsDirectory(project, true);
+    }
+
+    private Path resolveResultsDirectory(final MavenProject project, final boolean logWarnings) {
+        Path resolvedDirectory = null;
+        final Path moduleDirectory = getModuleDirectory(project);
+        if (moduleDirectory == null) {
+            logInvalidResultsDirectory(project, "module directory is not available", logWarnings);
+        } else {
+            final Path buildDirectory = getBuildDirectory(project, moduleDirectory, logWarnings);
+            final Path relativeDirectory = getRelativeResultsDirectory(project, logWarnings);
+            if (buildDirectory != null && relativeDirectory != null) {
+                resolvedDirectory = buildDirectory.resolve(relativeDirectory).normalize();
+                if (!resolvedDirectory.startsWith(moduleDirectory)) {
+                    logInvalidResultsDirectory(project,
+                            "results directory resolves outside module: " + resolvedDirectory,
+                            logWarnings);
+                    resolvedDirectory = null;
+                }
+            }
+        }
+        return resolvedDirectory;
+    }
+
+    private Path getRelativeResultsDirectory(final MavenProject project,
+            final boolean logWarnings) {
+        final String configuredResultsDirectory = getConfiguredResultsDirectory(project);
+        try {
+            final Path relativeDirectory = Paths.get(configuredResultsDirectory);
+            if (relativeDirectory.isAbsolute()) {
+                logInvalidResultsDirectory(project,
+                        "results directory should not be absolute for aggregate goal: "
+                                + configuredResultsDirectory,
+                        logWarnings);
+                return null;
+            }
+            return relativeDirectory;
+        } catch (InvalidPathException e) {
+            logInvalidResultsDirectory(project,
+                    "results directory path is invalid: " + configuredResultsDirectory,
+                    logWarnings);
+            return null;
+        }
+    }
+
+    private Path getBuildDirectory(final MavenProject project, final Path moduleDirectory,
+            final boolean logWarnings) {
+        if (project.getBuild() == null || StringUtils.isBlank(project.getBuild().getDirectory())) {
+            logInvalidResultsDirectory(project, "build directory is not available", logWarnings);
+            return null;
+        }
+
+        try {
+            Path buildDirectory = Paths.get(project.getBuild().getDirectory());
+            if (!buildDirectory.isAbsolute()) {
+                buildDirectory = moduleDirectory.resolve(buildDirectory);
+            }
+            return buildDirectory.toAbsolutePath().normalize();
+        } catch (InvalidPathException e) {
+            logInvalidResultsDirectory(project,
+                    "build directory path is invalid: " + project.getBuild().getDirectory(),
+                    logWarnings);
+            return null;
+        }
+    }
+
+    private Path getModuleDirectory(final MavenProject project) {
+        if (project == null || project.getBasedir() == null) {
+            return null;
+        }
+        return project.getBasedir().toPath().toAbsolutePath().normalize();
+    }
+
+    private String getConfiguredResultsDirectory(final MavenProject project) {
+        if (project != null && project.getProperties() != null) {
+            final String propertyOverride =
+                    project.getProperties().getProperty(RESULTS_DIRECTORY_PROPERTY);
+            if (StringUtils.isNotBlank(propertyOverride)) {
+                return propertyOverride;
+            }
+        }
+        return resultsDirectory;
+    }
+
+    private void logInvalidResultsDirectory(final MavenProject project, final String reason,
+            final boolean logWarnings) {
+        if (logWarnings) {
+            getLog().warn(MODULE_RESULTS_DIRECTORY_PREFIX + getProjectLabel(project)
+                    + " is invalid for aggregate goal: " + reason + ".");
+        }
+    }
+
+    private String getProjectLabel(final MavenProject project) {
+        if (project == null) {
+            return UNAVAILABLE_PROJECT_LABEL;
+        }
+        if (StringUtils.isNotBlank(project.getName())) {
+            return project.getName();
+        }
+        if (StringUtils.isNotBlank(project.getArtifactId())) {
+            return project.getArtifactId();
+        }
+        return UNAVAILABLE_PROJECT_LABEL;
     }
 
 }

--- a/src/test/java/io/qameta/allure/maven/AllureAggregateMojoTest.java
+++ b/src/test/java/io/qameta/allure/maven/AllureAggregateMojoTest.java
@@ -23,6 +23,7 @@ import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -33,7 +34,9 @@ import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 
 public class AllureAggregateMojoTest {
@@ -100,12 +103,97 @@ public class AllureAggregateMojoTest {
     }
 
     @Test
+    public void shouldUseChildResultsDirectoryPropertyOverrideWhenPresent() throws Exception {
+        final Path workspace = Files.createTempDirectory("allure-aggregate-property-override");
+        try {
+            final MavenProject project =
+                    createProject(workspace, "child", "Child", "child-results");
+            project.getProperties().setProperty("allure.results.directory", "child-results");
+
+            final TestAggregateMojo mojo =
+                    new TestAggregateMojo(Collections.singletonList(project), null);
+
+            assertThat(mojo.getInputDirectories(),
+                    contains(resultsDirectory(project, "child-results")));
+        } finally {
+            FileUtils.deleteQuietly(workspace.toFile());
+        }
+    }
+
+    @Test
+    public void shouldAllowResultsDirectoryThatResolvesWithinModule() throws Exception {
+        final Path workspace = Files.createTempDirectory("allure-aggregate-module-relative");
+        try {
+            final MavenProject project =
+                    createProject(workspace, "child", "Child", "../allure-results");
+
+            final TestAggregateMojo mojo =
+                    new TestAggregateMojo(Collections.singletonList(project), null);
+            mojo.setResultsDirectoryValue("../allure-results");
+
+            assertThat(mojo.getInputDirectories(),
+                    contains(resultsDirectory(project, "../allure-results")));
+        } finally {
+            FileUtils.deleteQuietly(workspace.toFile());
+        }
+    }
+
+    @Test
+    public void shouldSkipResultsDirectoryOutsideModule() throws Exception {
+        final Path workspace = Files.createTempDirectory("allure-aggregate-module-escape");
+        try {
+            createDirectories(workspace.resolve("shared-results"));
+            final MavenProject project =
+                    createProject(workspace, "child", "Child", "../../shared-results");
+
+            final RecordingLog log = new RecordingLog();
+            final TestAggregateMojo mojo =
+                    new TestAggregateMojo(Collections.singletonList(project), null);
+            mojo.setResultsDirectoryValue("../../shared-results");
+            mojo.setLog(log);
+
+            assertThat(mojo.getInputDirectories(), is(empty()));
+            assertThat(log.warnMessages,
+                    hasItem(containsString("results directory resolves outside module")));
+        } finally {
+            FileUtils.deleteQuietly(workspace.toFile());
+        }
+    }
+
+    @Test
+    public void shouldSkipAbsoluteResultsDirectoryOverride() throws Exception {
+        final Path workspace = Files.createTempDirectory("allure-aggregate-absolute-override");
+        try {
+            final Path absoluteResults = workspace.resolve("absolute-results").toAbsolutePath();
+            createDirectories(absoluteResults);
+            final MavenProject project = createProject(workspace, "child", "Child");
+            project.getProperties().setProperty("allure.results.directory",
+                    absoluteResults.toString());
+
+            final RecordingLog log = new RecordingLog();
+            final TestAggregateMojo mojo =
+                    new TestAggregateMojo(Collections.singletonList(project), null);
+            mojo.setLog(log);
+
+            assertThat(mojo.getInputDirectories(), is(empty()));
+            assertThat(log.warnMessages,
+                    hasItem(containsString("should not be absolute for aggregate goal")));
+        } finally {
+            FileUtils.deleteQuietly(workspace.toFile());
+        }
+    }
+
+    @Test
     public void shouldPreserveChildExecutorInfoWhenAggregating() throws Exception {
         final Path workspace = Files.createTempDirectory("allure-aggregate-executor");
         try {
-            final MavenProject currentProject = createProject(workspace, "current", "Current");
+            final MavenProject currentProject =
+                    createProject(workspace, "current", "Current", "current-results");
             final MavenProject childProject = createProject(workspace, "child", "Child");
-            final Path currentResultsDirectory = resultsDirectory(currentProject);
+            currentProject.getProperties().setProperty("allure.results.directory",
+                    "current-results");
+            final Path currentResultsDirectory =
+                    resultsDirectory(currentProject, "current-results");
             final Path childResultsDirectory = resultsDirectory(childProject);
             final Path childExecutor = childResultsDirectory.resolve("executor.json");
 
@@ -160,10 +248,18 @@ public class AllureAggregateMojoTest {
     }
 
     private static MavenProject createProject(final Path workspace, final String directoryName,
-            final String projectName) throws Exception {
+            final String projectName, final String... resultsDirectories) throws Exception {
         final Path projectDirectory = workspace.resolve(directoryName);
         final Path buildDirectory = projectDirectory.resolve("target");
-        Files.createDirectories(buildDirectory.resolve("allure-results"));
+        createDirectories(projectDirectory);
+        Files.writeString(projectDirectory.resolve("pom.xml"), "<project/>");
+        if (resultsDirectories.length == 0) {
+            createDirectories(buildDirectory.resolve("allure-results"));
+        } else {
+            for (String resultsDirectory : resultsDirectories) {
+                createDirectories(buildDirectory.resolve(resultsDirectory).normalize());
+            }
+        }
 
         final Build build = new Build();
         build.setDirectory(buildDirectory.toString());
@@ -171,11 +267,22 @@ public class AllureAggregateMojoTest {
         final MavenProject project = new MavenProject();
         project.setName(projectName);
         project.setBuild(build);
+        project.setFile(projectDirectory.resolve("pom.xml").toFile());
         return project;
     }
 
     private static Path resultsDirectory(final MavenProject project) {
         return Paths.get(project.getBuild().getDirectory(), "allure-results").toAbsolutePath();
+    }
+
+    private static Path resultsDirectory(final MavenProject project,
+            final String configuredResultsDirectory) {
+        return Paths.get(project.getBuild().getDirectory()).resolve(configuredResultsDirectory)
+                .toAbsolutePath().normalize();
+    }
+
+    private static void createDirectories(final Path directory) throws IOException {
+        Files.createDirectories(directory);
     }
 
     private static final class TestAggregateMojo extends AllureAggregateMojo {
@@ -206,6 +313,10 @@ public class AllureAggregateMojoTest {
 
         private void copyExecutorInfoTo(final List<Path> inputDirectories) throws Exception {
             copyExecutorInfo(inputDirectories);
+        }
+
+        private void setResultsDirectoryValue(final String resultsDirectory) {
+            this.resultsDirectory = resultsDirectory;
         }
     }
 


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

This fixes `allure:aggregate` in multi-module builds where modules do not all write results to the same default location.

Before this change, aggregate reporting could miss results because it treated the configured `resultsDirectory` as one shared path. That worked for simple setups, but broke when child modules used their own relative results path.

With this change, `allure:aggregate` now resolves the results directory separately for each module:

- It uses the child module’s `allure.results.directory` property when present.
- Otherwise it falls back to the plugin’s configured `resultsDirectory`.
- Relative paths are resolved from each module’s own `target` directory.
- Absolute paths are still rejected for `aggregate`.

This means aggregate reports now work as expected when:
- the root build uses a non-default `resultsDirectory`
- one or more child modules override `allure.results.directory`
- modules keep results inside their own project directory, including paths like `../allure-results` from `target`

Notes:
- Paths that resolve outside a module’s directory are skipped with a warning.
- `allure.properties` and `report.properties` are still not used for aggregate input discovery.
- Multiple explicit input directories are still out of scope for `aggregate`; users who need that should continue using `allure:report` with `inputDirectories`.

Fixes #106.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2