### PR TITLE
Preserve trend history automatically for allure:report

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,19 @@ For Allure 3, the plugin supports:
 JSON/YAML configs are merged into a generated config file, while JS/MJS/CJS configs are wrapped so
 the plugin can still overlay the report output, report name, and `singleFile` setting.
 
+### Trend history for `allure:report`
+
+The `report` goal preserves trend history automatically by default.
+
+- configure it with `allure.history.enabled` (`true` by default)
+- scope: `allure:report` only; `allure:aggregate` and `allure:serve` keep their current behavior
+- Allure 2: the plugin restores the previous `history/` directory from
+  `${allure.install.directory}/history/report/history` into a temporary input directory before
+  generation, then refreshes the cache from the newly generated report
+- Allure 3: the plugin sets default `historyPath` and `appendHistory=true` values that point to
+  `${allure.install.directory}/history/report/history.jsonl`; explicit values in your Allure 3
+  config still win
+
 ### Allure 3 serve behavior
 
 For Allure 3, `allure:serve` performs:

--- a/src/it/report-history-allure3/pom.xml
+++ b/src/it/report-history-allure3/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.qameta.allure-maven.it</groupId>
+    <artifactId>allure-maven-it</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>Allure Report History Test</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
+    <reporting>
+        <excludeDefaults>true</excludeDefaults>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <reportVersion>3.4.1</reportVersion>
+                </configuration>
+            </plugin>
+        </plugins>
+    </reporting>
+
+</project>

--- a/src/it/report-history-allure3/setup.groovy
+++ b/src/it/report-history-allure3/setup.groovy
@@ -1,0 +1,11 @@
+import java.nio.file.Paths
+
+import static io.qameta.allure.maven.Allure3SetupHelper.prepareFakeReportRuntime
+
+def basedirPath = basedir.toPath().toAbsolutePath()
+prepareFakeReportRuntime(
+        basedirPath.resolve('.allure'),
+        basedirPath.resolve(Paths.get('target', 'allure3 history args.txt')),
+        basedirPath.resolve(Paths.get('target', 'site', 'allure-maven-plugin')),
+        true
+)

--- a/src/it/report-history-allure3/target/allure-results/sample-testsuite.xml
+++ b/src/it/report-history-allure3/target/allure-results/sample-testsuite.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ns2:test-suite xmlns:ns2="urn:model.allure.qatools.yandex.ru" start="1412949538848" stop="1412949560045"
+                version="1.4.4-SNAPSHOT">
+    <name>my.company.Sample</name>
+    <test-cases>
+        <test-case start="1412949539363" stop="1412949539730" status="passed">
+            <name>sampleTestCase</name>
+        </test-case>
+    </test-cases>
+</ns2:test-suite>

--- a/src/it/report-history-allure3/verify.groovy
+++ b/src/it/report-history-allure3/verify.groovy
@@ -1,0 +1,31 @@
+import groovy.json.JsonSlurper
+import java.nio.file.Files
+import java.nio.file.Paths
+
+import static io.qameta.allure.maven.TestHelper.checkRegularReportMojoOnly
+import static io.qameta.allure.maven.TestHelper.checkReportDirectory
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.Matchers.is
+import static ru.yandex.qatools.matchers.nio.PathMatchers.isDirectory
+
+def basedirPath = basedir.absolutePath
+def outputDirectory = Paths.get(basedirPath, 'target', 'site', 'allure-maven-plugin')
+def configPath = Paths.get(basedirPath, 'target', 'allure-maven', 'allure3', 'allurerc.json')
+def historyFile = Paths.get(basedirPath, '.allure', 'history', 'report', 'history.jsonl')
+def resultsPath = Paths.get(basedirPath, 'target', 'allure-results')
+def allureCli = Paths.get(basedirPath, '.allure', 'allure-3.4.1', 'node_modules', 'allure',
+        'cli.js').toAbsolutePath().toString()
+def args = Files.readAllLines(Paths.get(basedirPath, 'target', 'allure3 history args.txt'))
+
+checkRegularReportMojoOnly(Paths.get(basedirPath))
+checkReportDirectory(outputDirectory, 1)
+
+def expectedInvocation = [ "cli=${allureCli}", 'command=generate', 'arg=generate',
+        "arg=${resultsPath.toAbsolutePath()}", 'arg=--config',
+        "arg=${configPath.toAbsolutePath()}", '---' ].collect { it.toString() }
+assertThat(args, is(expectedInvocation))
+
+def config = new JsonSlurper().parse(configPath.toFile())
+assertThat(config.historyPath, is(historyFile.toAbsolutePath().toString()))
+assertThat(config.appendHistory, is(true))
+assertThat(historyFile.parent, isDirectory())

--- a/src/main/java/io/qameta/allure/maven/Allure3Commandline.java
+++ b/src/main/java/io/qameta/allure/maven/Allure3Commandline.java
@@ -43,6 +43,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -119,13 +120,20 @@ public class Allure3Commandline {
     public int generateReport(final List<Path> resultsPaths, final Path reportPath,
             final boolean singleFile, final Path buildDirectory, final String reportName,
             final Path userConfigPath) throws IOException {
+        return generateReport(resultsPaths, reportPath, singleFile, buildDirectory, reportName,
+                userConfigPath, Collections.<String, Object>emptyMap());
+    }
+
+    public int generateReport(final List<Path> resultsPaths, final Path reportPath,
+            final boolean singleFile, final Path buildDirectory, final String reportName,
+            final Path userConfigPath, final Map<String, Object> defaultConfig) throws IOException {
         checkAllureExists();
         ensureLaunchers();
         FileUtils.deleteQuietly(reportPath.toFile());
 
         final Path workDirectory = prepareWorkDirectory(buildDirectory);
-        final Path config =
-                writeConfig(workDirectory, reportPath, singleFile, reportName, userConfigPath);
+        final Path config = writeConfig(workDirectory, reportPath, singleFile, reportName,
+                userConfigPath, defaultConfig);
 
         return executeGenerate(resultsPaths, config);
     }
@@ -138,8 +146,8 @@ public class Allure3Commandline {
         FileUtils.deleteQuietly(reportPath.toFile());
 
         final Path workDirectory = prepareWorkDirectory(buildDirectory);
-        final Path config =
-                writeConfig(workDirectory, reportPath, singleFile, reportName, userConfigPath);
+        final Path config = writeConfig(workDirectory, reportPath, singleFile, reportName,
+                userConfigPath, Collections.<String, Object>emptyMap());
 
         executeGenerate(resultsPaths, config);
         return executeOpen(reportPath, config, servePort);
@@ -392,14 +400,15 @@ public class Allure3Commandline {
     }
 
     private Path writeConfig(final Path workDirectory, final Path reportPath,
-            final boolean singleFile, final String reportName, final Path userConfigPath)
-            throws IOException {
+            final boolean singleFile, final String reportName, final Path userConfigPath,
+            final Map<String, Object> defaultConfig) throws IOException {
         if (isScriptConfig(userConfigPath)) {
             return writeScriptConfig(workDirectory, reportPath, singleFile, reportName,
-                    userConfigPath);
+                    userConfigPath, defaultConfig);
         }
 
         final Map<String, Object> config = readConfig(userConfigPath);
+        applyDefaultConfig(config, defaultConfig);
         config.put("name", reportName);
         config.put("output", reportPath.toAbsolutePath().toString());
 
@@ -415,11 +424,11 @@ public class Allure3Commandline {
     }
 
     private Path writeScriptConfig(final Path workDirectory, final Path reportPath,
-            final boolean singleFile, final String reportName, final Path userConfigPath)
-            throws IOException {
+            final boolean singleFile, final String reportName, final Path userConfigPath,
+            final Map<String, Object> defaultConfig) throws IOException {
         final ObjectMapper mapper = new ObjectMapper();
         final Path configPath = workDirectory.resolve("allurerc.mjs");
-        final List<String> lines = Arrays.asList(
+        final List<String> lines = new java.util.ArrayList<>(Arrays.asList(
                 "import userConfig from " + mapper.writeValueAsString(
                         userConfigPath.toAbsolutePath().toUri().toString()) + ";",
                 "", "const config = userConfig ?? {};",
@@ -430,14 +439,26 @@ public class Allure3Commandline {
                 "const awesomeOptions = typeof awesome.options === \"object\" "
                         + "&& awesome.options !== null",
                 "  ? awesome.options", "  : {};", "", "export default {", "  ...config,",
-                "  name: " + mapper.writeValueAsString(reportName) + ",",
-                "  output: " + mapper.writeValueAsString(reportPath.toAbsolutePath().toString())
-                        + ",",
-                "  plugins: {", "    ...plugins,", "    awesome: {", "      ...awesome,",
-                "      options: {", "        ...awesomeOptions,",
-                "        singleFile: " + singleFile + ",", "      },", "    },", "  },", "};", "");
+                "  name: " + mapper.writeValueAsString(reportName) + ",", "  output: "
+                        + mapper.writeValueAsString(reportPath.toAbsolutePath().toString()) + ","));
+        for (Map.Entry<String, Object> entry : defaultConfig.entrySet()) {
+            lines.add("  " + entry.getKey() + ": config." + entry.getKey() + " ?? "
+                    + mapper.writeValueAsString(entry.getValue()) + ",");
+        }
+        lines.addAll(Arrays.asList("  plugins: {", "    ...plugins,", "    awesome: {",
+                "      ...awesome,", "      options: {", "        ...awesomeOptions,",
+                "        singleFile: " + singleFile + ",", "      },", "    },", "  },", "};", ""));
         Files.write(configPath, lines, StandardCharsets.UTF_8);
         return configPath;
+    }
+
+    private void applyDefaultConfig(final Map<String, Object> config,
+            final Map<String, Object> defaultConfig) {
+        for (Map.Entry<String, Object> entry : defaultConfig.entrySet()) {
+            if (!config.containsKey(entry.getKey())) {
+                config.put(entry.getKey(), entry.getValue());
+            }
+        }
     }
 
     private Map<String, Object> readConfig(final Path userConfigPath) throws IOException {

--- a/src/main/java/io/qameta/allure/maven/AllureGenerateMojo.java
+++ b/src/main/java/io/qameta/allure/maven/AllureGenerateMojo.java
@@ -45,6 +45,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 
 import static io.qameta.allure.maven.Allure3Commandline.NODE_DEFAULT_DOWNLOAD_URL;
@@ -202,13 +203,31 @@ public abstract class AllureGenerateMojo extends AllureBaseMojo {
             this.loadProperties(inputDirectories);
             this.loadCategories(inputDirectories);
             this.copyExecutorInfo(inputDirectories);
-            this.generateReport(inputDirectories, allureVersion);
+            final List<Path> generationInputDirectories =
+                    prepareInputDirectoriesForGenerate(inputDirectories, allureVersion);
+            this.generateReport(generationInputDirectories, allureVersion);
+            afterGenerateReport(generationInputDirectories, allureVersion);
 
             render(getSink(), getName(locale));
 
         } catch (Exception e) {
             throw new MavenReportException("Could not generate the report", e);
         }
+    }
+
+    protected List<Path> prepareInputDirectoriesForGenerate(final List<Path> inputDirectories,
+            final AllureVersion allureVersion) throws IOException {
+        return inputDirectories;
+    }
+
+    protected void afterGenerateReport(final List<Path> inputDirectories,
+            final AllureVersion allureVersion) throws IOException {
+        Objects.requireNonNull(inputDirectories, "inputDirectories");
+        Objects.requireNonNull(allureVersion, "allureVersion");
+    }
+
+    protected Map<String, Object> getAllure3ConfigDefaults() throws IOException {
+        return Collections.emptyMap();
     }
 
     protected void copyExecutorInfo(final List<Path> inputDirectories) throws IOException {
@@ -348,7 +367,8 @@ public abstract class AllureGenerateMojo extends AllureBaseMojo {
 
             getLog().info("Generate report to " + reportPath);
             commandline.generateReport(resultsPaths, reportPath, Boolean.TRUE.equals(singleFile),
-                    Paths.get(buildDirectory), getName(Locale.getDefault()), allureConfig);
+                    Paths.get(buildDirectory), getName(Locale.getDefault()), allureConfig,
+                    getAllure3ConfigDefaults());
             getLog().info("Report generated successfully.");
         } catch (Exception e) {
             getLog().error("Generation error", e);

--- a/src/main/java/io/qameta/allure/maven/AllureReportMojo.java
+++ b/src/main/java/io/qameta/allure/maven/AllureReportMojo.java
@@ -15,16 +15,21 @@
  */
 package io.qameta.allure.maven;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import static java.lang.String.format;
 
@@ -36,6 +41,9 @@ public class AllureReportMojo extends AllureGenerateMojo {
 
     private static final String FOUND_DIRECTORY = "Found results directory %s";
     private static final String DIRECTORY_NOT_FOUND = "Directory %s not found";
+    private static final String HISTORY_DIRECTORY_NAME = "history";
+    private static final String REPORT_DIRECTORY_NAME = "report";
+    private static final String TO_PATH_SEPARATOR = " to ";
 
     /**
      * The comma-separated list of additional input directories. As long as unix path can contains
@@ -44,6 +52,9 @@ public class AllureReportMojo extends AllureGenerateMojo {
      */
     @Parameter(property = "allure.results.inputDirectories")
     protected String inputDirectories;
+
+    @Parameter(property = "allure.history.enabled", defaultValue = "true")
+    protected boolean historyEnabled;
 
     /**
      * {@inheritDoc}
@@ -80,11 +91,91 @@ public class AllureReportMojo extends AllureGenerateMojo {
 
     @Override
     protected String getMojoName() {
-        return "report";
+        return REPORT_DIRECTORY_NAME;
+    }
+
+    @Override
+    protected List<Path> prepareInputDirectoriesForGenerate(final List<Path> inputDirectories,
+            final AllureVersion allureVersion) throws IOException {
+        if (!historyEnabled || allureVersion.isAllure3()) {
+            return inputDirectories;
+        }
+
+        final Path cachedHistoryDirectory = getCachedAllure2HistoryDirectory();
+        if (!isDirectoryExists(cachedHistoryDirectory)) {
+            getLog().info("No cached Allure history found at " + cachedHistoryDirectory);
+            return inputDirectories;
+        }
+
+        final Path historyInputDirectory = restoreCachedHistoryInput(cachedHistoryDirectory);
+        final List<Path> generationInputDirectories = new ArrayList<>(inputDirectories);
+        generationInputDirectories.add(historyInputDirectory);
+        getLog().info("Restored cached Allure history from " + cachedHistoryDirectory
+                + TO_PATH_SEPARATOR + historyInputDirectory.resolve(HISTORY_DIRECTORY_NAME));
+        return generationInputDirectories;
+    }
+
+    @Override
+    protected void afterGenerateReport(final List<Path> inputDirectories,
+            final AllureVersion allureVersion) throws IOException {
+        if (!historyEnabled || allureVersion.isAllure3()) {
+            return;
+        }
+
+        final Path generatedHistoryDirectory =
+                Paths.get(getReportDirectory()).resolve(HISTORY_DIRECTORY_NAME);
+        if (!isDirectoryExists(generatedHistoryDirectory)) {
+            return;
+        }
+
+        final Path cacheRoot = getReportHistoryCacheDirectory();
+        final Path cachedHistoryDirectory = cacheRoot.resolve(HISTORY_DIRECTORY_NAME);
+        FileUtils.deleteQuietly(cacheRoot.toFile());
+        Files.createDirectories(cacheRoot);
+        FileUtils.copyDirectory(generatedHistoryDirectory.toFile(),
+                cachedHistoryDirectory.toFile());
+        getLog().info("Refreshed cached Allure history from " + generatedHistoryDirectory
+                + TO_PATH_SEPARATOR + cachedHistoryDirectory);
+    }
+
+    @Override
+    protected Map<String, Object> getAllure3ConfigDefaults() throws IOException {
+        if (!historyEnabled) {
+            return Collections.emptyMap();
+        }
+
+        final Path historyFile = getReportHistoryCacheDirectory().resolve("history.jsonl");
+        Files.createDirectories(historyFile.getParent());
+        getLog().info("Using Allure 3 history file " + historyFile.toAbsolutePath());
+
+        final Map<String, Object> defaults = new LinkedHashMap<>();
+        defaults.put("historyPath", historyFile.toAbsolutePath().toString());
+        defaults.put("appendHistory", true);
+        return defaults;
     }
 
     private Path getInputDirectoryAbsolutePath() {
         final Path path = Paths.get(resultsDirectory);
         return path.isAbsolute() ? path : Paths.get(buildDirectory).resolve(path);
+    }
+
+    private Path restoreCachedHistoryInput(final Path cachedHistoryDirectory) throws IOException {
+        final Path historyInputRoot =
+                Paths.get(buildDirectory).resolve(Paths.get("allure-maven", "history-input"));
+        final Path historyInputDirectory = historyInputRoot.resolve("allure-results");
+        final Path restoredHistoryDirectory = historyInputDirectory.resolve(HISTORY_DIRECTORY_NAME);
+        FileUtils.deleteQuietly(historyInputRoot.toFile());
+        Files.createDirectories(historyInputDirectory);
+        FileUtils.copyDirectory(cachedHistoryDirectory.toFile(), restoredHistoryDirectory.toFile());
+        return historyInputDirectory;
+    }
+
+    private Path getReportHistoryCacheDirectory() {
+        return Paths.get(getInstallDirectory())
+                .resolve(Paths.get(HISTORY_DIRECTORY_NAME, REPORT_DIRECTORY_NAME));
+    }
+
+    private Path getCachedAllure2HistoryDirectory() {
+        return getReportHistoryCacheDirectory().resolve(HISTORY_DIRECTORY_NAME);
     }
 }

--- a/src/test/java/io/qameta/allure/maven/Allure3CommandlineTest.java
+++ b/src/test/java/io/qameta/allure/maven/Allure3CommandlineTest.java
@@ -24,9 +24,12 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -117,8 +120,13 @@ public class Allure3CommandlineTest {
             Allure3SetupHelper.prepareFakeReportRuntime(installDirectory, capturedArgs,
                     reportDirectory, true);
 
+            final Map<String, Object> defaultConfig = new LinkedHashMap<>();
+            defaultConfig.put("historyPath", testDirectory
+                    .resolve(Paths.get("history", "history.jsonl")).toAbsolutePath().toString());
+            defaultConfig.put("appendHistory", true);
+
             commandline.generateReport(Arrays.asList(resultsDirectory, secondResultsDirectory),
-                    reportDirectory, true, buildDirectory, "Allure", null);
+                    reportDirectory, true, buildDirectory, "Allure", null, defaultConfig);
 
             final Path config = buildDirectory.resolve("allure-maven").resolve("allure3")
                     .resolve("allurerc.json");
@@ -126,6 +134,9 @@ public class Allure3CommandlineTest {
             assertThat(configJson.get("name").asText(), is("Allure"));
             assertThat(configJson.get("output").asText(),
                     is(reportDirectory.toAbsolutePath().toString()));
+            assertThat(configJson.get("historyPath").asText(),
+                    is(defaultConfig.get("historyPath")));
+            assertThat(configJson.get("appendHistory").asBoolean(), is(true));
             assertThat(configJson.get("plugins").get("awesome").get("options").get("singleFile")
                     .asBoolean(), is(true));
             assertThat(reportDirectory.resolve("index.html"), exists());
@@ -167,8 +178,13 @@ public class Allure3CommandlineTest {
             Allure3SetupHelper.prepareFakeReportRuntime(installDirectory,
                     testDirectory.resolve("node-args.txt"), reportDirectory, false);
 
+            final Map<String, Object> defaultConfig = new LinkedHashMap<>();
+            defaultConfig.put("historyPath", testDirectory
+                    .resolve(Paths.get("history", "history.jsonl")).toAbsolutePath().toString());
+            defaultConfig.put("appendHistory", true);
+
             commandline.generateReport(Collections.singletonList(resultsDirectory), reportDirectory,
-                    true, buildDirectory, "Allure", userConfig);
+                    true, buildDirectory, "Allure", userConfig, defaultConfig);
 
             final Path config = buildDirectory.resolve("allure-maven").resolve("allure3")
                     .resolve("allurerc.json");
@@ -176,6 +192,9 @@ public class Allure3CommandlineTest {
             assertThat(configJson.get("name").asText(), is("Allure"));
             assertThat(configJson.get("output").asText(),
                     is(reportDirectory.toAbsolutePath().toString()));
+            assertThat(configJson.get("historyPath").asText(),
+                    is(defaultConfig.get("historyPath")));
+            assertThat(configJson.get("appendHistory").asBoolean(), is(true));
             assertThat(configJson.get("plugins").get("custom").get("enabled").asBoolean(),
                     is(true));
             assertThat(configJson.get("plugins").get("awesome").get("options").get("collapseSuites")
@@ -214,8 +233,13 @@ public class Allure3CommandlineTest {
             Allure3SetupHelper.prepareFakeReportRuntime(installDirectory,
                     testDirectory.resolve("node-args.txt"), reportDirectory, false);
 
+            final Map<String, Object> defaultConfig = new LinkedHashMap<>();
+            defaultConfig.put("historyPath", testDirectory
+                    .resolve(Paths.get("history", "history.jsonl")).toAbsolutePath().toString());
+            defaultConfig.put("appendHistory", true);
+
             commandline.generateReport(Collections.singletonList(resultsDirectory), reportDirectory,
-                    true, buildDirectory, "Allure", userConfig);
+                    true, buildDirectory, "Allure", userConfig, defaultConfig);
 
             final Path generatedConfig = buildDirectory.resolve("allure-maven").resolve("allure3")
                     .resolve("allurerc.mjs");
@@ -226,6 +250,11 @@ public class Allure3CommandlineTest {
                     .writeValueAsString(userConfig.toAbsolutePath().toUri().toString()) + ";"));
             assertThat(generatedConfigLines, hasItem("  name: \"Allure\","));
             assertThat(generatedConfigLines, hasItem("        singleFile: true,"));
+            assertThat(generatedConfigLines, hasItem("  historyPath: config.historyPath ?? "
+                    + new ObjectMapper().writeValueAsString(defaultConfig.get("historyPath"))
+                    + ","));
+            assertThat(generatedConfigLines,
+                    hasItem("  appendHistory: config.appendHistory ?? true,"));
         } finally {
             FileUtils.deleteQuietly(testDirectory.toFile());
         }

--- a/src/test/java/io/qameta/allure/maven/AllureReportMojoTest.java
+++ b/src/test/java/io/qameta/allure/maven/AllureReportMojoTest.java
@@ -1,0 +1,243 @@
+/*
+ *  Copyright 2016-2024 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.maven;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.maven.plugin.logging.Log;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+public class AllureReportMojoTest {
+
+    @Test
+    public void shouldRestoreCachedAllure2HistoryIntoSeparateInputDirectory() throws Exception {
+        final Path workspace = Files.createTempDirectory("allure-report-history-restore");
+        try {
+            final Path resultsDirectory = workspace.resolve(Paths.get("build", "allure-results"));
+            final Path cachedHistoryDirectory =
+                    workspace.resolve(Paths.get("install", "history", "report", "history"));
+            Files.createDirectories(resultsDirectory);
+            Files.createDirectories(cachedHistoryDirectory);
+            Files.writeString(cachedHistoryDirectory.resolve("history-trend.json"),
+                    "{\"cached\":true}", StandardCharsets.UTF_8);
+
+            final TestReportMojo mojo = new TestReportMojo();
+            mojo.buildDirectory = workspace.resolve("build").toString();
+            mojo.installDirectory = workspace.resolve("install").toString();
+            mojo.historyEnabled = true;
+
+            final List<Path> preparedInputDirectories =
+                    mojo.prepareInputDirectoriesForGeneratePublic(
+                            java.util.Collections.singletonList(resultsDirectory),
+                            AllureVersion.resolve("2.30.0"));
+
+            final Path historyInputDirectory = workspace
+                    .resolve(Paths.get("build", "allure-maven", "history-input", "allure-results"));
+            assertThat(preparedInputDirectories.size(), is(2));
+            assertThat(preparedInputDirectories.get(0), is(resultsDirectory));
+            assertThat(preparedInputDirectories.get(1), is(historyInputDirectory));
+            assertThat(Files.exists(
+                    historyInputDirectory.resolve(Paths.get("history", "history-trend.json"))),
+                    is(true));
+            assertThat(Files.exists(resultsDirectory.resolve("history")), is(false));
+        } finally {
+            FileUtils.deleteQuietly(workspace.toFile());
+        }
+    }
+
+    @Test
+    public void shouldSkipHistoryRestoreWhenDisabled() throws Exception {
+        final Path workspace = Files.createTempDirectory("allure-report-history-disabled");
+        try {
+            final Path resultsDirectory = workspace.resolve(Paths.get("build", "allure-results"));
+            final Path cachedHistoryDirectory =
+                    workspace.resolve(Paths.get("install", "history", "report", "history"));
+            Files.createDirectories(resultsDirectory);
+            Files.createDirectories(cachedHistoryDirectory);
+            Files.writeString(cachedHistoryDirectory.resolve("history-trend.json"),
+                    "{\"cached\":true}", StandardCharsets.UTF_8);
+
+            final TestReportMojo mojo = new TestReportMojo();
+            mojo.buildDirectory = workspace.resolve("build").toString();
+            mojo.installDirectory = workspace.resolve("install").toString();
+            mojo.historyEnabled = false;
+
+            final List<Path> preparedInputDirectories =
+                    mojo.prepareInputDirectoriesForGeneratePublic(
+                            java.util.Collections.singletonList(resultsDirectory),
+                            AllureVersion.resolve("2.30.0"));
+
+            assertThat(preparedInputDirectories.size(), is(1));
+            assertThat(preparedInputDirectories.get(0), is(resultsDirectory));
+            assertThat(
+                    Files.exists(
+                            workspace.resolve(Paths.get("build", "allure-maven", "history-input"))),
+                    is(false));
+        } finally {
+            FileUtils.deleteQuietly(workspace.toFile());
+        }
+    }
+
+    @Test
+    public void shouldRefreshCachedAllure2HistoryFromGeneratedReport() throws Exception {
+        final Path workspace = Files.createTempDirectory("allure-report-history-refresh");
+        try {
+            final Path reportHistoryDirectory = workspace.resolve(Paths.get("report", "history"));
+            final Path cacheRoot = workspace.resolve(Paths.get("install", "history", "report"));
+            final Path cachedHistoryDirectory = cacheRoot.resolve("history");
+            Files.createDirectories(reportHistoryDirectory);
+            Files.createDirectories(cachedHistoryDirectory);
+            Files.writeString(cachedHistoryDirectory.resolve("obsolete.json"), "obsolete",
+                    StandardCharsets.UTF_8);
+            Files.writeString(reportHistoryDirectory.resolve("history-trend.json"),
+                    "{\"generated\":true}", StandardCharsets.UTF_8);
+
+            final TestReportMojo mojo = new TestReportMojo();
+            mojo.installDirectory = workspace.resolve("install").toString();
+            mojo.reportDirectory = workspace.resolve("report").toString();
+            mojo.historyEnabled = true;
+
+            mojo.afterGenerateReportPublic(java.util.Collections.<Path>emptyList(),
+                    AllureVersion.resolve("2.30.0"));
+
+            assertThat(Files.exists(cachedHistoryDirectory.resolve("obsolete.json")), is(false));
+            assertThat(Files.readString(cachedHistoryDirectory.resolve("history-trend.json"),
+                    StandardCharsets.UTF_8), is("{\"generated\":true}"));
+        } finally {
+            FileUtils.deleteQuietly(workspace.toFile());
+        }
+    }
+
+    @Test
+    public void shouldProvideAllure3HistoryDefaultsWhenEnabled() throws Exception {
+        final Path workspace = Files.createTempDirectory("allure-report-history-allure3");
+        try {
+            final RecordingLog log = new RecordingLog();
+            final TestReportMojo mojo = new TestReportMojo();
+            mojo.installDirectory = workspace.resolve("install").toString();
+            mojo.historyEnabled = true;
+            mojo.setLog(log);
+
+            final Map<String, Object> defaults = mojo.getAllure3ConfigDefaultsPublic();
+            final Path historyFile =
+                    workspace.resolve(Paths.get("install", "history", "report", "history.jsonl"));
+
+            assertThat(defaults.get("historyPath"), is(historyFile.toAbsolutePath().toString()));
+            assertThat(defaults.get("appendHistory"), is((Object) Boolean.TRUE));
+            assertThat(Files.isDirectory(historyFile.getParent()), is(true));
+            assertThat(log.infoMessages.get(0), containsString("Using Allure 3 history file"));
+        } finally {
+            FileUtils.deleteQuietly(workspace.toFile());
+        }
+    }
+
+    private static final class TestReportMojo extends AllureReportMojo {
+
+        private List<Path> prepareInputDirectoriesForGeneratePublic(
+                final List<Path> inputDirectories, final AllureVersion allureVersion)
+                throws IOException {
+            return super.prepareInputDirectoriesForGenerate(inputDirectories, allureVersion);
+        }
+
+        private void afterGenerateReportPublic(final List<Path> inputDirectories,
+                final AllureVersion allureVersion) throws IOException {
+            super.afterGenerateReport(inputDirectories, allureVersion);
+        }
+
+        private Map<String, Object> getAllure3ConfigDefaultsPublic() throws IOException {
+            return super.getAllure3ConfigDefaults();
+        }
+    }
+
+    private static final class RecordingLog implements Log {
+
+        private final List<String> infoMessages = new ArrayList<String>();
+
+        @Override
+        public boolean isDebugEnabled() {
+            return false;
+        }
+
+        @Override
+        public void debug(final CharSequence content) {}
+
+        @Override
+        public void debug(final CharSequence content, final Throwable error) {}
+
+        @Override
+        public void debug(final Throwable error) {}
+
+        @Override
+        public boolean isInfoEnabled() {
+            return true;
+        }
+
+        @Override
+        public void info(final CharSequence content) {
+            infoMessages.add(content.toString());
+        }
+
+        @Override
+        public void info(final CharSequence content, final Throwable error) {
+            info(content);
+        }
+
+        @Override
+        public void info(final Throwable error) {
+            info(error.getMessage());
+        }
+
+        @Override
+        public boolean isWarnEnabled() {
+            return false;
+        }
+
+        @Override
+        public void warn(final CharSequence content) {}
+
+        @Override
+        public void warn(final CharSequence content, final Throwable error) {}
+
+        @Override
+        public void warn(final Throwable error) {}
+
+        @Override
+        public boolean isErrorEnabled() {
+            return false;
+        }
+
+        @Override
+        public void error(final CharSequence content) {}
+
+        @Override
+        public void error(final CharSequence content, final Throwable error) {}
+
+        @Override
+        public void error(final Throwable error) {}
+    }
+}


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

`allure:report` now preserves trend history automatically between runs.

Before this change, users had to copy history files by hand to keep trend widgets and history data in the next report. With this update, that carry-forward happens by default for the `report` goal.

Fixes #183.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2