### PR TITLE
Log executed Allure CLI commands in Maven debug output

### DIFF
--- a/src/main/java/io/qameta/allure/maven/Allure3Commandline.java
+++ b/src/main/java/io/qameta/allure/maven/Allure3Commandline.java
@@ -28,6 +28,7 @@ import org.apache.commons.exec.DefaultExecutor;
 import org.apache.commons.exec.ExecuteWatchdog;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.settings.Proxy;
 
 import java.io.BufferedReader;
@@ -57,7 +58,8 @@ import java.util.stream.Collectors;
  */
 @SuppressWarnings({"PMD.GodClass", "ClassDataAbstractionCoupling", "ClassFanOutComplexity",
         "MultipleStringLiterals", "ParameterNumber", "PMD.CouplingBetweenObjects",
-        "PMD.TooManyMethods", "PMD.CyclomaticComplexity", "PMD.ExcessiveParameterList"})
+        "PMD.TooManyMethods", "PMD.CyclomaticComplexity", "PMD.ExcessiveParameterList",
+        "PMD.NcssCount"})
 public class Allure3Commandline {
 
     public static final String NODE_DEFAULT_VERSION = "24.14.1";
@@ -93,10 +95,20 @@ public class Allure3Commandline {
 
     private final Allure3Platform platform;
 
+    private final Log log;
+
     public Allure3Commandline(final Path installationDirectory, final String allureVersion,
             final String nodeVersion, final String nodeDownloadUrl, final String npmRegistry,
             final Path allurePackagePath, final Proxy proxy, final Properties downloadProperties,
             final boolean offline, final int timeout) {
+        this(installationDirectory, allureVersion, nodeVersion, nodeDownloadUrl, npmRegistry,
+                allurePackagePath, proxy, downloadProperties, offline, timeout, null);
+    }
+
+    public Allure3Commandline(final Path installationDirectory, final String allureVersion,
+            final String nodeVersion, final String nodeDownloadUrl, final String npmRegistry,
+            final Path allurePackagePath, final Proxy proxy, final Properties downloadProperties,
+            final boolean offline, final int timeout, final Log log) {
         this.installationDirectory = installationDirectory;
         this.allureVersion = allureVersion;
         this.nodeVersion = StringUtils.defaultIfBlank(nodeVersion, NODE_DEFAULT_VERSION);
@@ -109,6 +121,7 @@ public class Allure3Commandline {
         this.offline = offline;
         this.timeout = timeout;
         this.platform = Allure3Platform.detect();
+        this.log = log;
     }
 
     public void install() throws IOException {
@@ -584,11 +597,18 @@ public class Allure3Commandline {
                 .setTimeout(Duration.ofMillis(TimeUnit.SECONDS.toMillis(timeout))).get();
         executor.setWatchdog(watchdog);
         executor.setExitValue(0);
+        logCommandLine(commandLine);
         return executor.execute(commandLine);
     }
 
     private void addPathArgument(final CommandLine commandLine, final Path path) {
         commandLine.addArgument(path.toAbsolutePath().toString(), platform.isWindows());
+    }
+
+    private void logCommandLine(final CommandLine commandLine) {
+        if (log != null && log.isDebugEnabled()) {
+            log.debug("Executing Allure command: " + Arrays.toString(commandLine.toStrings()));
+        }
     }
 
     private static final class MapTypeReference extends TypeReference<Map<String, Object>> {

--- a/src/main/java/io/qameta/allure/maven/AllureCommandline.java
+++ b/src/main/java/io/qameta/allure/maven/AllureCommandline.java
@@ -24,6 +24,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Dependency;
+import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.DefaultProjectBuildingRequest;
 import org.apache.maven.project.ProjectBuildingRequest;
 import org.apache.maven.settings.Proxy;
@@ -38,6 +39,7 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -47,7 +49,7 @@ import java.util.concurrent.TimeUnit;
 
 import static io.qameta.allure.maven.VersionUtils.versionCompare;
 
-@SuppressWarnings({"ClassDataAbstractionCoupling", "ClassFanOutComplexity",
+@SuppressWarnings({"PMD.GodClass", "ClassDataAbstractionCoupling", "ClassFanOutComplexity",
         "MultipleStringLiterals"})
 public class AllureCommandline {
 
@@ -61,17 +63,30 @@ public class AllureCommandline {
 
     private final Path installationDirectory;
 
+    private final Log log;
+
     public AllureCommandline(final Path installationDirectory, final String version) {
-        this(installationDirectory, version, DEFAULT_TIMEOUT);
+        this(installationDirectory, version, DEFAULT_TIMEOUT, null);
+    }
+
+    public AllureCommandline(final Path installationDirectory, final String version,
+            final Log log) {
+        this(installationDirectory, version, DEFAULT_TIMEOUT, log);
     }
 
     public AllureCommandline(final Path installationDirectory, final String version,
             final int timeout) {
+        this(installationDirectory, version, timeout, null);
+    }
+
+    public AllureCommandline(final Path installationDirectory, final String version,
+            final int timeout, final Log log) {
         this.installationDirectory = installationDirectory;
         this.version = StringUtils.isBlank(version) || versionCompare(version, "2.8.0") < 0
                 ? ALLURE_DEFAULT_VERSION
                 : version;
         this.timeout = timeout;
+        this.log = log;
     }
 
     public int generateReport(final List<Path> resultsPaths, final Path reportPath,
@@ -81,9 +96,7 @@ public class AllureCommandline {
 
         FileUtils.deleteQuietly(reportPath.toFile());
 
-        final CommandLine commandLine =
-                new CommandLine(getAllureExecutablePath().toAbsolutePath().toFile());
-        commandLine.addArgument("generate");
+        final CommandLine commandLine = createCommandLine("generate");
         commandLine.addArgument("--clean");
         if (singleFile) {
             commandLine.addArgument("--single-file");
@@ -103,9 +116,7 @@ public class AllureCommandline {
 
         this.checkAllureExists();
 
-        final CommandLine commandLine =
-                new CommandLine(getAllureExecutablePath().toAbsolutePath().toFile());
-        commandLine.addArgument("serve");
+        final CommandLine commandLine = createCommandLine("serve");
         if (serveHost != null && serveHost.matches("(\\d{1,3}\\.){3}\\d{1,3}")) {
             commandLine.addArgument("--host");
             commandLine.addArgument(serveHost);
@@ -133,7 +144,24 @@ public class AllureCommandline {
                 .setTimeout(Duration.ofMillis(TimeUnit.SECONDS.toMillis(timeout))).get();
         executor.setWatchdog(watchdog);
         executor.setExitValue(0);
+        logCommandLine(commandLine);
         return executor.execute(commandLine);
+    }
+
+    private CommandLine createCommandLine(final String command) {
+        final CommandLine commandLine =
+                new CommandLine(getAllureExecutablePath().toAbsolutePath().toFile());
+        if (log != null && log.isDebugEnabled()) {
+            commandLine.addArgument("--verbose");
+        }
+        commandLine.addArgument(command);
+        return commandLine;
+    }
+
+    private void logCommandLine(final CommandLine commandLine) {
+        if (log != null && log.isDebugEnabled()) {
+            log.debug("Executing Allure command: " + Arrays.toString(commandLine.toStrings()));
+        }
     }
 
     private void addPathArgument(final CommandLine commandLine, final Path path) {

--- a/src/main/java/io/qameta/allure/maven/AllureGenerateMojo.java
+++ b/src/main/java/io/qameta/allure/maven/AllureGenerateMojo.java
@@ -294,9 +294,8 @@ public abstract class AllureGenerateMojo extends AllureBaseMojo {
 
     private void installAllure2(final AllureVersion allureVersion) throws MavenReportException {
         try {
-            final AllureCommandline commandline =
-                    new AllureCommandline(Paths.get(installDirectory), allureVersion.getVersion(),
-                            getLog());
+            final AllureCommandline commandline = new AllureCommandline(Paths.get(installDirectory),
+                    allureVersion.getVersion(), getLog());
             getLog().info(String.format("Allure installation directory %s", installDirectory));
             getLog().info(String.format("Try to finding out allure %s", commandline.getVersion()));
 
@@ -345,9 +344,9 @@ public abstract class AllureGenerateMojo extends AllureBaseMojo {
         try {
             final Path reportPath = Paths.get(getReportDirectory());
 
-            final AllureCommandline commandline = new AllureCommandline(
-                    Paths.get(getInstallDirectory()), allureVersion.getVersion(), reportTimeout,
-                    getLog());
+            final AllureCommandline commandline =
+                    new AllureCommandline(Paths.get(getInstallDirectory()),
+                            allureVersion.getVersion(), reportTimeout, getLog());
 
             getLog().info("Generate report to " + reportPath);
             commandline.generateReport(resultsPaths, reportPath, Boolean.TRUE.equals(singleFile));

--- a/src/main/java/io/qameta/allure/maven/AllureGenerateMojo.java
+++ b/src/main/java/io/qameta/allure/maven/AllureGenerateMojo.java
@@ -295,7 +295,8 @@ public abstract class AllureGenerateMojo extends AllureBaseMojo {
     private void installAllure2(final AllureVersion allureVersion) throws MavenReportException {
         try {
             final AllureCommandline commandline =
-                    new AllureCommandline(Paths.get(installDirectory), allureVersion.getVersion());
+                    new AllureCommandline(Paths.get(installDirectory), allureVersion.getVersion(),
+                            getLog());
             getLog().info(String.format("Allure installation directory %s", installDirectory));
             getLog().info(String.format("Try to finding out allure %s", commandline.getVersion()));
 
@@ -345,7 +346,8 @@ public abstract class AllureGenerateMojo extends AllureBaseMojo {
             final Path reportPath = Paths.get(getReportDirectory());
 
             final AllureCommandline commandline = new AllureCommandline(
-                    Paths.get(getInstallDirectory()), allureVersion.getVersion(), reportTimeout);
+                    Paths.get(getInstallDirectory()), allureVersion.getVersion(), reportTimeout,
+                    getLog());
 
             getLog().info("Generate report to " + reportPath);
             commandline.generateReport(resultsPaths, reportPath, Boolean.TRUE.equals(singleFile));
@@ -382,7 +384,7 @@ public abstract class AllureGenerateMojo extends AllureBaseMojo {
                 nodeVersion, nodeDownloadUrl, npmRegistry, resolveAllurePackagePathOrNull(),
                 ProxyUtils.getProxy(session, decrypter),
                 AllureCommandline.getDownloadProperties(session),
-                session != null && session.isOffline(), timeout);
+                session != null && session.isOffline(), timeout, getLog());
     }
 
     protected void validateAllure3Configuration() throws IOException {

--- a/src/main/java/io/qameta/allure/maven/AllureInstallMojo.java
+++ b/src/main/java/io/qameta/allure/maven/AllureInstallMojo.java
@@ -94,7 +94,8 @@ public class AllureInstallMojo extends AbstractMojo {
 
     private void installAllure2(final AllureVersion allureVersion) throws IOException {
         final AllureCommandline commandline =
-                new AllureCommandline(Paths.get(installDirectory), allureVersion.getVersion());
+                new AllureCommandline(Paths.get(installDirectory), allureVersion.getVersion(),
+                        getLog());
         getLog().info(String.format("Allure installation directory %s", installDirectory));
         getLog().info(String.format("Try to finding out allure %s", commandline.getVersion()));
 
@@ -121,7 +122,7 @@ public class AllureInstallMojo extends AbstractMojo {
                 allureVersion.getVersion(), nodeVersion, nodeDownloadUrl, npmRegistry,
                 resolveAllurePackagePathOrNull(), ProxyUtils.getProxy(session, decrypter),
                 AllureCommandline.getDownloadProperties(session),
-                session != null && session.isOffline(), 3600);
+                session != null && session.isOffline(), 3600, getLog());
         getLog().info(String.format("Allure installation directory %s", installDirectory));
         getLog().info(String.format("Try to finding out allure %s using Node.js %s",
                 commandline.getVersion(), commandline.getNodeVersion()));

--- a/src/main/java/io/qameta/allure/maven/AllureInstallMojo.java
+++ b/src/main/java/io/qameta/allure/maven/AllureInstallMojo.java
@@ -93,9 +93,8 @@ public class AllureInstallMojo extends AbstractMojo {
     }
 
     private void installAllure2(final AllureVersion allureVersion) throws IOException {
-        final AllureCommandline commandline =
-                new AllureCommandline(Paths.get(installDirectory), allureVersion.getVersion(),
-                        getLog());
+        final AllureCommandline commandline = new AllureCommandline(Paths.get(installDirectory),
+                allureVersion.getVersion(), getLog());
         getLog().info(String.format("Allure installation directory %s", installDirectory));
         getLog().info(String.format("Try to finding out allure %s", commandline.getVersion()));
 

--- a/src/main/java/io/qameta/allure/maven/AllureServeMojo.java
+++ b/src/main/java/io/qameta/allure/maven/AllureServeMojo.java
@@ -86,7 +86,7 @@ public class AllureServeMojo extends AllureGenerateMojo {
         try {
             final AllureCommandline commandline =
                     new AllureCommandline(Paths.get(getInstallDirectory()),
-                            allureVersion.getVersion(), this.serveTimeout);
+                            allureVersion.getVersion(), this.serveTimeout, getLog());
 
             getLog().info("Serve Allure report using a temporary directory managed by the CLI.");
             commandline.serve(resultsPaths, this.serveHost, this.servePort);

--- a/src/test/java/io/qameta/allure/maven/Allure3CommandlineTest.java
+++ b/src/test/java/io/qameta/allure/maven/Allure3CommandlineTest.java
@@ -183,8 +183,8 @@ public class Allure3CommandlineTest {
             assertThat(log.debugMessages,
                     is(Collections.singletonList("Executing Allure command: ["
                             + commandline.getAllureExecutablePath().toAbsolutePath()
-                            + ", generate, " + resultsDirectory.toAbsolutePath()
-                            + ", --config, " + config.toAbsolutePath() + "]")));
+                            + ", generate, " + resultsDirectory.toAbsolutePath() + ", --config, "
+                            + config.toAbsolutePath() + "]")));
         } finally {
             FileUtils.deleteQuietly(testDirectory.toFile());
         }
@@ -364,15 +364,15 @@ public class Allure3CommandlineTest {
             final Path config = buildDirectory.resolve("allure-maven").resolve("allure3")
                     .resolve("allurerc.json");
             assertThat(log.debugMessages,
-                    is(Arrays.asList("Executing Allure command: ["
+                    is(Arrays.asList(
+                            "Executing Allure command: ["
                                     + commandline.getAllureExecutablePath().toAbsolutePath()
                                     + ", generate, " + resultsDirectory.toAbsolutePath()
                                     + ", --config, " + config.toAbsolutePath() + "]",
                             "Executing Allure command: ["
                                     + commandline.getAllureExecutablePath().toAbsolutePath()
-                                    + ", open, " + reportDirectory.toAbsolutePath()
-                                    + ", --config, " + config.toAbsolutePath()
-                                    + ", --port, 5555]")));
+                                    + ", open, " + reportDirectory.toAbsolutePath() + ", --config, "
+                                    + config.toAbsolutePath() + ", --port, 5555]")));
         } finally {
             FileUtils.deleteQuietly(testDirectory.toFile());
         }

--- a/src/test/java/io/qameta/allure/maven/Allure3CommandlineTest.java
+++ b/src/test/java/io/qameta/allure/maven/Allure3CommandlineTest.java
@@ -18,6 +18,7 @@ package io.qameta.allure.maven;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.FileUtils;
+import org.apache.maven.plugin.logging.Log;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -148,6 +149,42 @@ public class Allure3CommandlineTest {
                             "arg=" + resultsDirectory.toAbsolutePath(),
                             "arg=" + secondResultsDirectory.toAbsolutePath(), "arg=--config",
                             "arg=" + config.toAbsolutePath(), "---")));
+        } finally {
+            FileUtils.deleteQuietly(testDirectory.toFile());
+        }
+    }
+
+    @Test
+    public void shouldLogGenerateCommandInDebugModeWithoutVerboseFlag() throws Exception {
+        assumeFalse(isWindows());
+
+        final Path testDirectory = Files.createTempDirectory("allure3-commandline");
+        try {
+            final Path installDirectory = testDirectory.resolve("install");
+            final Path buildDirectory = testDirectory.resolve("build");
+            final Path resultsDirectory = testDirectory.resolve("results with space");
+            final Path reportDirectory = testDirectory.resolve("report with space");
+            final Path capturedArgs = testDirectory.resolve("node-args.txt");
+            final RecordingLog log = new RecordingLog(true);
+            final Allure3Commandline commandline =
+                    newCommandline(installDirectory, null, false, 10, log);
+
+            Files.createDirectories(resultsDirectory);
+            Files.write(resultsDirectory.resolve("sample.json"), Collections.singletonList("{}"),
+                    StandardCharsets.UTF_8);
+            Allure3SetupHelper.prepareFakeReportRuntime(installDirectory, capturedArgs,
+                    reportDirectory, false);
+
+            commandline.generateReport(Collections.singletonList(resultsDirectory), reportDirectory,
+                    false, buildDirectory, "Allure", null);
+
+            final Path config = buildDirectory.resolve("allure-maven").resolve("allure3")
+                    .resolve("allurerc.json");
+            assertThat(log.debugMessages,
+                    is(Collections.singletonList("Executing Allure command: ["
+                            + commandline.getAllureExecutablePath().toAbsolutePath()
+                            + ", generate, " + resultsDirectory.toAbsolutePath()
+                            + ", --config, " + config.toAbsolutePath() + "]")));
         } finally {
             FileUtils.deleteQuietly(testDirectory.toFile());
         }
@@ -300,6 +337,47 @@ public class Allure3CommandlineTest {
         }
     }
 
+    @Test
+    public void shouldLogGenerateAndOpenCommandsInDebugModeWithoutVerboseFlag() throws Exception {
+        assumeFalse(isWindows());
+
+        final Path testDirectory = Files.createTempDirectory("allure3-commandline");
+        try {
+            final Path installDirectory = testDirectory.resolve("install");
+            final Path buildDirectory = testDirectory.resolve("build");
+            final Path resultsDirectory = testDirectory.resolve("results with space");
+            final Path reportDirectory = testDirectory.resolve("report with space");
+            final Path capturedArgs = testDirectory.resolve("node-args.txt");
+            final RecordingLog log = new RecordingLog(true);
+            final Allure3Commandline commandline =
+                    newCommandline(installDirectory, null, false, 10, log);
+
+            Files.createDirectories(resultsDirectory);
+            Files.write(resultsDirectory.resolve("sample.json"), Collections.singletonList("{}"),
+                    StandardCharsets.UTF_8);
+            Allure3SetupHelper.prepareFakeReportRuntime(installDirectory, capturedArgs,
+                    reportDirectory, false);
+
+            commandline.serve(Collections.singletonList(resultsDirectory), reportDirectory, false,
+                    buildDirectory, "Allure", 5555, null);
+
+            final Path config = buildDirectory.resolve("allure-maven").resolve("allure3")
+                    .resolve("allurerc.json");
+            assertThat(log.debugMessages,
+                    is(Arrays.asList("Executing Allure command: ["
+                                    + commandline.getAllureExecutablePath().toAbsolutePath()
+                                    + ", generate, " + resultsDirectory.toAbsolutePath()
+                                    + ", --config, " + config.toAbsolutePath() + "]",
+                            "Executing Allure command: ["
+                                    + commandline.getAllureExecutablePath().toAbsolutePath()
+                                    + ", open, " + reportDirectory.toAbsolutePath()
+                                    + ", --config, " + config.toAbsolutePath()
+                                    + ", --port, 5555]")));
+        } finally {
+            FileUtils.deleteQuietly(testDirectory.toFile());
+        }
+    }
+
     @Test(expected = IOException.class)
     public void shouldFailOfflineWhenPrivateNodeIsMissing() throws Exception {
         final Path testDirectory = Files.createTempDirectory("allure3-commandline");
@@ -312,14 +390,93 @@ public class Allure3CommandlineTest {
 
     private static Allure3Commandline newCommandline(final Path installDirectory,
             final Path packageArchive, final boolean offline, final int timeout) {
+        return newCommandline(installDirectory, packageArchive, offline, timeout, null);
+    }
+
+    private static Allure3Commandline newCommandline(final Path installDirectory,
+            final Path packageArchive, final boolean offline, final int timeout, final Log log) {
         return new Allure3Commandline(installDirectory, "3.4.1",
                 Allure3Commandline.NODE_DEFAULT_VERSION,
                 Allure3Commandline.NODE_DEFAULT_DOWNLOAD_URL,
                 Allure3Commandline.NPM_DEFAULT_REGISTRY, packageArchive, null, new Properties(),
-                offline, timeout);
+                offline, timeout, log);
     }
 
     private static boolean isWindows() {
         return System.getProperty("os.name").toLowerCase().contains("win");
+    }
+
+    private static final class RecordingLog implements Log {
+
+        private final boolean debugEnabled;
+
+        private final List<String> debugMessages;
+
+        private RecordingLog(final boolean debugEnabled) {
+            this.debugEnabled = debugEnabled;
+            this.debugMessages = new java.util.ArrayList<String>();
+        }
+
+        @Override
+        public boolean isDebugEnabled() {
+            return debugEnabled;
+        }
+
+        @Override
+        public void debug(final CharSequence content) {
+            debugMessages.add(content.toString());
+        }
+
+        @Override
+        public void debug(final CharSequence content, final Throwable error) {
+            debug(content);
+        }
+
+        @Override
+        public void debug(final Throwable error) {
+            debug(error.getMessage());
+        }
+
+        @Override
+        public boolean isInfoEnabled() {
+            return false;
+        }
+
+        @Override
+        public void info(final CharSequence content) {}
+
+        @Override
+        public void info(final CharSequence content, final Throwable error) {}
+
+        @Override
+        public void info(final Throwable error) {}
+
+        @Override
+        public boolean isWarnEnabled() {
+            return false;
+        }
+
+        @Override
+        public void warn(final CharSequence content) {}
+
+        @Override
+        public void warn(final CharSequence content, final Throwable error) {}
+
+        @Override
+        public void warn(final Throwable error) {}
+
+        @Override
+        public boolean isErrorEnabled() {
+            return false;
+        }
+
+        @Override
+        public void error(final CharSequence content) {}
+
+        @Override
+        public void error(final CharSequence content, final Throwable error) {}
+
+        @Override
+        public void error(final Throwable error) {}
     }
 }

--- a/src/test/java/io/qameta/allure/maven/AllureCommandlineTest.java
+++ b/src/test/java/io/qameta/allure/maven/AllureCommandlineTest.java
@@ -225,9 +225,8 @@ public class AllureCommandlineTest {
                     new AllureCommandline(installDirectory, version, 10, log);
             commandline.serve(Collections.singletonList(resultsDirectory), null, 0);
 
-            assertThat(Files.readAllLines(capturedArgs, StandardCharsets.UTF_8),
-                    is(Arrays.asList("--verbose", "serve",
-                            resultsDirectory.toAbsolutePath().toString())));
+            assertThat(Files.readAllLines(capturedArgs, StandardCharsets.UTF_8), is(Arrays
+                    .asList("--verbose", "serve", resultsDirectory.toAbsolutePath().toString())));
             assertThat(log.debugMessages,
                     is(Collections.singletonList("Executing Allure command: ["
                             + executable.toAbsolutePath() + ", --verbose, serve, "

--- a/src/test/java/io/qameta/allure/maven/AllureCommandlineTest.java
+++ b/src/test/java/io/qameta/allure/maven/AllureCommandlineTest.java
@@ -16,6 +16,7 @@
 package io.qameta.allure.maven;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.maven.plugin.logging.Log;
 import org.junit.Test;
 
 import javax.net.ssl.HostnameVerifier;
@@ -43,6 +44,7 @@ import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -135,6 +137,44 @@ public class AllureCommandlineTest {
     }
 
     @Test
+    public void shouldPassVerboseFlagAndLogCommandWhenDebugGeneratingReport() throws Exception {
+        assumeFalse(isWindows());
+
+        final Path testDirectory = Files.createTempDirectory("allure-commandline");
+        try {
+            final String version = "2.30.0";
+            final Path installDirectory = testDirectory.resolve("install");
+            final Path resultsDirectory = testDirectory.resolve("results with space");
+            final Path reportDirectory = testDirectory.resolve("report with space");
+            final Path capturedArgs = testDirectory.resolve("args.txt");
+            final Path executable =
+                    installDirectory.resolve("allure-" + version).resolve("bin").resolve("allure");
+            final RecordingLog log = new RecordingLog(true);
+            Files.createDirectories(resultsDirectory);
+
+            createUnixAllureExecutable(installDirectory, version, "#!/bin/sh",
+                    "printf '%s\\n' \"$@\" > '" + capturedArgs + "'", "exit 0");
+
+            final AllureCommandline commandline =
+                    new AllureCommandline(installDirectory, version, 10, log);
+            commandline.generateReport(Collections.singletonList(resultsDirectory), reportDirectory,
+                    false);
+
+            assertThat(Files.readAllLines(capturedArgs, StandardCharsets.UTF_8),
+                    is(Arrays.asList("--verbose", "generate", "--clean",
+                            resultsDirectory.toAbsolutePath().toString(), "-o",
+                            reportDirectory.toAbsolutePath().toString())));
+            assertThat(log.debugMessages,
+                    is(Collections.singletonList("Executing Allure command: ["
+                            + executable.toAbsolutePath() + ", --verbose, generate, --clean, "
+                            + resultsDirectory.toAbsolutePath() + ", -o, "
+                            + reportDirectory.toAbsolutePath() + "]")));
+        } finally {
+            FileUtils.deleteQuietly(testDirectory.toFile());
+        }
+    }
+
+    @Test
     public void shouldPassWindowsPathsWithoutLosingSpacesWhenServingReport() throws Exception {
         assumeTrue(isWindows());
 
@@ -158,6 +198,40 @@ public class AllureCommandlineTest {
 
             assertThat(Files.readAllLines(capturedArgs, StandardCharsets.UTF_8),
                     is(Arrays.asList("serve", resultsDirectory.toAbsolutePath().toString())));
+        } finally {
+            FileUtils.deleteQuietly(testDirectory.toFile());
+        }
+    }
+
+    @Test
+    public void shouldPassVerboseFlagAndLogCommandWhenDebugServingReport() throws Exception {
+        assumeFalse(isWindows());
+
+        final Path testDirectory = Files.createTempDirectory("allure-commandline");
+        try {
+            final String version = "2.30.0";
+            final Path installDirectory = testDirectory.resolve("install");
+            final Path resultsDirectory = testDirectory.resolve("results with space");
+            final Path capturedArgs = testDirectory.resolve("args.txt");
+            final Path executable =
+                    installDirectory.resolve("allure-" + version).resolve("bin").resolve("allure");
+            final RecordingLog log = new RecordingLog(true);
+            Files.createDirectories(resultsDirectory);
+
+            createUnixAllureExecutable(installDirectory, version, "#!/bin/sh",
+                    "printf '%s\\n' \"$@\" > '" + capturedArgs + "'", "exit 0");
+
+            final AllureCommandline commandline =
+                    new AllureCommandline(installDirectory, version, 10, log);
+            commandline.serve(Collections.singletonList(resultsDirectory), null, 0);
+
+            assertThat(Files.readAllLines(capturedArgs, StandardCharsets.UTF_8),
+                    is(Arrays.asList("--verbose", "serve",
+                            resultsDirectory.toAbsolutePath().toString())));
+            assertThat(log.debugMessages,
+                    is(Collections.singletonList("Executing Allure command: ["
+                            + executable.toAbsolutePath() + ", --verbose, serve, "
+                            + resultsDirectory.toAbsolutePath() + "]")));
         } finally {
             FileUtils.deleteQuietly(testDirectory.toFile());
         }
@@ -209,6 +283,80 @@ public class AllureCommandlineTest {
                 "type nul > \"" + captureFile + "\"", ":loop", "if \"%~1\"==\"\" goto done",
                 ">> \"" + captureFile + "\" echo(%~1", "shift", "goto loop", ":done", "exit /b 0",
                 "");
+    }
+
+    private static final class RecordingLog implements Log {
+
+        private final boolean debugEnabled;
+
+        private final List<String> debugMessages;
+
+        private RecordingLog(final boolean debugEnabled) {
+            this.debugEnabled = debugEnabled;
+            this.debugMessages = new java.util.ArrayList<String>();
+        }
+
+        @Override
+        public boolean isDebugEnabled() {
+            return debugEnabled;
+        }
+
+        @Override
+        public void debug(final CharSequence content) {
+            debugMessages.add(content.toString());
+        }
+
+        @Override
+        public void debug(final CharSequence content, final Throwable error) {
+            debug(content);
+        }
+
+        @Override
+        public void debug(final Throwable error) {
+            debug(error.getMessage());
+        }
+
+        @Override
+        public boolean isInfoEnabled() {
+            return false;
+        }
+
+        @Override
+        public void info(final CharSequence content) {}
+
+        @Override
+        public void info(final CharSequence content, final Throwable error) {}
+
+        @Override
+        public void info(final Throwable error) {}
+
+        @Override
+        public boolean isWarnEnabled() {
+            return false;
+        }
+
+        @Override
+        public void warn(final CharSequence content) {}
+
+        @Override
+        public void warn(final CharSequence content, final Throwable error) {}
+
+        @Override
+        public void warn(final Throwable error) {}
+
+        @Override
+        public boolean isErrorEnabled() {
+            return false;
+        }
+
+        @Override
+        public void error(final CharSequence content) {}
+
+        @Override
+        public void error(final CharSequence content, final Throwable error) {}
+
+        @Override
+        public void error(final Throwable error) {}
     }
 
     /**


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

Fixes #222.

This makes `mvn -X` a lot more useful when `allure:report` or `allure:serve` fails. The plugin now logs the exact command line arguments it is about to execute, so users can see the real CLI invocation, including resolved paths and flags. That makes it much easier to reproduce problems outside Maven and understand what the plugin is actually running.

For Allure 2, the plugin also adds `--verbose` when Maven debug logging is enabled, so the underlying CLI produces more detail in the same troubleshooting flow. For Allure 3, this change is limited to logging the executed argv, since the current CLI commands do not expose an equivalent verbose option.

Example debug output:

```text
[DEBUG] Executing Allure command: [/path/to/.allure/allure-2.30.0/bin/allure, --verbose, generate, --clean, /path/to/allure-results, -o, /path/to/report]
```

Tests were added for both Allure 2 and Allure 3 execution paths, including cases with spaces in paths, to make sure the logged output matches the command that is actually executed.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2