### PR TITLE
Stop allure:serve process on Ctrl+C

### DIFF
--- a/src/main/java/io/qameta/allure/maven/Allure3Commandline.java
+++ b/src/main/java/io/qameta/allure/maven/Allure3Commandline.java
@@ -24,8 +24,6 @@ import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.commons.exec.CommandLine;
-import org.apache.commons.exec.DefaultExecutor;
-import org.apache.commons.exec.ExecuteWatchdog;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.logging.Log;
@@ -42,7 +40,6 @@ import java.nio.file.Path;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -50,7 +47,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 /**
@@ -58,8 +54,7 @@ import java.util.stream.Collectors;
  */
 @SuppressWarnings({"PMD.GodClass", "ClassDataAbstractionCoupling", "ClassFanOutComplexity",
         "MultipleStringLiterals", "ParameterNumber", "PMD.CouplingBetweenObjects",
-        "PMD.TooManyMethods", "PMD.CyclomaticComplexity", "PMD.ExcessiveParameterList",
-        "PMD.NcssCount"})
+        "PMD.TooManyMethods", "PMD.CyclomaticComplexity", "PMD.ExcessiveParameterList"})
 public class Allure3Commandline {
 
     public static final String NODE_DEFAULT_VERSION = "24.14.1";
@@ -592,13 +587,8 @@ public class Allure3Commandline {
     }
 
     private int execute(final CommandLine commandLine, final int timeout) throws IOException {
-        final DefaultExecutor executor = DefaultExecutor.builder().get();
-        final ExecuteWatchdog watchdog = ExecuteWatchdog.builder()
-                .setTimeout(Duration.ofMillis(TimeUnit.SECONDS.toMillis(timeout))).get();
-        executor.setWatchdog(watchdog);
-        executor.setExitValue(0);
         logCommandLine(commandLine);
-        return executor.execute(commandLine);
+        return CommandLineExecutorFactory.newExecutor(timeout).execute(commandLine);
     }
 
     private void addPathArgument(final CommandLine commandLine, final Path path) {

--- a/src/main/java/io/qameta/allure/maven/AllureCommandline.java
+++ b/src/main/java/io/qameta/allure/maven/AllureCommandline.java
@@ -18,8 +18,6 @@ package io.qameta.allure.maven;
 import net.lingala.zip4j.ZipFile;
 import net.lingala.zip4j.exception.ZipException;
 import org.apache.commons.exec.CommandLine;
-import org.apache.commons.exec.DefaultExecutor;
-import org.apache.commons.exec.ExecuteWatchdog;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.execution.MavenSession;
@@ -38,14 +36,12 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
-import java.util.concurrent.TimeUnit;
 
 import static io.qameta.allure.maven.VersionUtils.versionCompare;
 
@@ -139,13 +135,8 @@ public class AllureCommandline {
     }
 
     private int execute(final CommandLine commandLine, final int timeout) throws IOException {
-        final DefaultExecutor executor = DefaultExecutor.builder().get();
-        final ExecuteWatchdog watchdog = ExecuteWatchdog.builder()
-                .setTimeout(Duration.ofMillis(TimeUnit.SECONDS.toMillis(timeout))).get();
-        executor.setWatchdog(watchdog);
-        executor.setExitValue(0);
         logCommandLine(commandLine);
-        return executor.execute(commandLine);
+        return CommandLineExecutorFactory.newExecutor(timeout).execute(commandLine);
     }
 
     private CommandLine createCommandLine(final String command) {

--- a/src/main/java/io/qameta/allure/maven/CommandLineExecutorFactory.java
+++ b/src/main/java/io/qameta/allure/maven/CommandLineExecutorFactory.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright 2016-2024 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.maven;
+
+import org.apache.commons.exec.DefaultExecutor;
+import org.apache.commons.exec.ExecuteWatchdog;
+import org.apache.commons.exec.ShutdownHookProcessDestroyer;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+final class CommandLineExecutorFactory {
+
+    private CommandLineExecutorFactory() {
+        // Utility class.
+    }
+
+    static DefaultExecutor newExecutor(final int timeout) {
+        final DefaultExecutor executor = DefaultExecutor.builder().get();
+        final ExecuteWatchdog watchdog = ExecuteWatchdog.builder()
+                .setTimeout(Duration.ofMillis(TimeUnit.SECONDS.toMillis(timeout))).get();
+        executor.setWatchdog(watchdog);
+        executor.setProcessDestroyer(new ShutdownHookProcessDestroyer());
+        executor.setExitValue(0);
+        return executor;
+    }
+}

--- a/src/test/java/io/qameta/allure/maven/CommandLineExecutorFactoryTest.java
+++ b/src/test/java/io/qameta/allure/maven/CommandLineExecutorFactoryTest.java
@@ -1,0 +1,65 @@
+/*
+ *  Copyright 2016-2024 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.maven;
+
+import org.apache.commons.exec.DefaultExecutor;
+import org.apache.commons.exec.ExecuteWatchdog;
+import org.apache.commons.exec.ShutdownHookProcessDestroyer;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.time.Duration;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class CommandLineExecutorFactoryTest {
+
+    @Test
+    public void shouldConfigureShutdownHookProcessDestroyer() {
+        final DefaultExecutor executor = CommandLineExecutorFactory.newExecutor(10);
+
+        assertThat(executor.getProcessDestroyer(), instanceOf(ShutdownHookProcessDestroyer.class));
+    }
+
+    @Test
+    public void shouldConfigureWatchdogTimeoutInSeconds() {
+        final ExecuteWatchdog watchdog = CommandLineExecutorFactory.newExecutor(10).getWatchdog();
+
+        assertThat(watchdog, notNullValue());
+        assertThat(getTimeout(watchdog), is(Duration.ofSeconds(10)));
+    }
+
+    @Test
+    public void shouldTreatOnlyZeroExitCodeAsSuccess() {
+        final DefaultExecutor executor = CommandLineExecutorFactory.newExecutor(10);
+
+        assertThat(executor.isFailure(0), is(false));
+        assertThat(executor.isFailure(1), is(true));
+    }
+
+    private static Duration getTimeout(final ExecuteWatchdog watchdog) {
+        try {
+            final Method getWatchdog = ExecuteWatchdog.class.getDeclaredMethod("getWatchdog");
+            getWatchdog.setAccessible(true);
+            return ((org.apache.commons.exec.Watchdog) getWatchdog.invoke(watchdog)).getTimeout();
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("Failed to inspect watchdog timeout", e);
+        }
+    }
+}


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

Fixes #245.

This fixes an issue where mvn allure:serve could leave the Allure server running after Maven was stopped with Ctrl+C. We were already using commons-exec to manage the child process timeout, but we were not registering shutdown cleanup for the spawned process. This change adds that cleanup so the child process is stopped when Maven exits.

The fix applies to both implementations behind allure:serve: Allure 2 and Allure 3. It also adds focused tests for the executor configuration so we keep the shutdown behavior covered.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2